### PR TITLE
Add possibility to work with LLVM dylib

### DIFF
--- a/GenXIntrinsics/CMakeLists.txt
+++ b/GenXIntrinsics/CMakeLists.txt
@@ -6,6 +6,8 @@ if(IGC_INFRA)
   set(GENX_INTRINSICS_MAIN_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include PARENT_SCOPE)
 endif()
 
+include(cmake/utils.cmake)
+
 set(GENX_INTRINSICS_DESCRIPTION "GenXIntrinsicDescription.gen")
 
 add_subdirectory(include/llvm)

--- a/GenXIntrinsics/cmake/utils.cmake
+++ b/GenXIntrinsics/cmake/utils.cmake
@@ -1,0 +1,18 @@
+# Convenience function to get list of LLVM components for
+# target_link_library. If LLVM was configured with llvm dylib, then
+# included in dylib llvm targets should be replaced with LLVM
+# lib. Otherwise, just return passed libraries.
+# ret -- name of variable with returned targets list. All other
+# arguments are targets to process.
+function(vc_get_llvm_targets RET)
+  set(TARGETS ${ARGN})
+  if (LLVM_LINK_LLVM_DYLIB)
+    if ("${LLVM_DYLIB_COMPONENTS}" STREQUAL "all")
+      set(TARGETS "")
+    else()
+      list(REMOVE_ITEM TARGETS ${LLVM_DYLIB_COMPONENTS})
+    endif()
+    set(TARGETS ${TARGETS} LLVM)
+  endif()
+  set(${RET} ${TARGETS} PARENT_SCOPE)
+endfunction()

--- a/GenXIntrinsics/lib/GenXIntrinsics/CMakeLists.txt
+++ b/GenXIntrinsics/lib/GenXIntrinsics/CMakeLists.txt
@@ -1,3 +1,8 @@
+set(LLVM_LIBS
+  LLVMCodeGen
+  LLVMSupport
+  )
+
 if(BUILD_EXTERNAL)
   add_library(LLVMGenXIntrinsics 
               GenXIntrinsics.cpp
@@ -8,8 +13,10 @@ if(BUILD_EXTERNAL)
              )
   llvm_update_compile_flags(LLVMGenXIntrinsics)
   add_dependencies(LLVMGenXIntrinsics GenXIntrinsicsGen)
-  add_dependencies(LLVMGenXIntrinsics LLVMCodeGen)
-  target_link_libraries(LLVMGenXIntrinsics LLVMCodeGen)
+
+  vc_get_llvm_targets(LLVM_LIBS ${LLVM_LIBS})
+  target_link_libraries(LLVMGenXIntrinsics ${LLVM_LIBS})
+
   target_include_directories(LLVMGenXIntrinsics PUBLIC
     $<BUILD_INTERFACE:${GENX_INTRINSICS_MAIN_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../../include>
@@ -29,8 +36,7 @@ else()
     ${GENX_INTRINSICS_MAIN_INCLUDE_DIR}/llvm/GenXIntrinsics
 
     LINK_LIBS
-      LLVMCodeGen
-      LLVMSupport
+      ${LLVM_LIBS}
 
     DEPENDS
       GenXIntrinsicsGen


### PR DESCRIPTION
If llvm was configured with LLVM_LINK_LLVM_DYLIB
then we should use LLVM target instead of static
libraries. Also we should not drop all libraries
because it can create unresolved references.