### PR TITLE
Add lit tests infrastructure

### DIFF
--- a/GenXIntrinsics/CMakeLists.txt
+++ b/GenXIntrinsics/CMakeLists.txt
@@ -21,8 +21,13 @@ endif()
 
 # Experimental lit tests for intrinsic passes. Require plugin support,
 # so only available with LLVM dylib (for stability).
-if(LLVM_LINK_LLVM_DYLIB)
-  add_subdirectory(test)
+if(VC_INTR_ENABLE_LIT_TESTS)
+  if(LLVM_LINK_LLVM_DYLIB)
+    message(STATUS "VC intrinsics lit tests are enabled")
+    add_subdirectory(test)
+  else()
+    message(STATUS "VC intrinsics lit tests require dynamic LLVM, skipping")
+  endif()
 endif()
 
 # this option is to switch on install when we are building not inside IGC

--- a/GenXIntrinsics/test/Adaptors/empty_kernel_writer.ll
+++ b/GenXIntrinsics/test/Adaptors/empty_kernel_writer.ll
@@ -1,0 +1,20 @@
+; Test empty kernel metadata translation: old -> new.
+
+; RUN: opt -S -GenXSPIRVWriterAdaptor < %s | FileCheck %s
+
+; CHECK: @test() #[[ATTR_GROUP:[0-9]+]]
+define void @test() #0 {
+  ret void
+}
+
+; CHECK: attributes #[[ATTR_GROUP]] = {
+; CHECK-DAG: "VCFunction"
+; CHECK-DAG: "VCSLMSize"="0"
+; CHECK: }
+attributes #0 = { "CMGenxMain" }
+
+; CHECK-NOT: !genx.kernels
+!genx.kernels = !{!0}
+
+!0 = !{void ()* @test, !"test", !1, i32 0, i32 0, !1, !1, i32 0, i32 0}
+!1 = !{}

--- a/GenXIntrinsics/test/CMakeLists.txt
+++ b/GenXIntrinsics/test/CMakeLists.txt
@@ -1,1 +1,60 @@
+if(BUILD_EXTERNAL)
+  if(NOT EXISTS ${LLVM_EXTERNAL_LIT})
+    message(FATAL_ERROR "External build requires LLVM_EXTERNAL_LIT to be defined to lit executable")
+  endif()
+endif()
+
+# Add plugin with all intrinsics libraries for loading with opt.
 add_subdirectory(Plugin)
+
+set(VC_INTRINSICS_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Generate temporary site config with LLVM variables filled.
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/temp.cfg.py
+  MAIN_CONFIG
+    ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+  )
+
+# Need to regenerate again since plugin name is required and proper
+# way to get it is to use generator expressions that are not allowed
+# in configure_file.
+file(GENERATE
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/vcint.$<CONFIG>.lit.site.cfg.py"
+  INPUT "${CMAKE_CURRENT_BINARY_DIR}/temp.cfg.py"
+  )
+
+set(USED_TOOLS
+  # These are required by lit default substitutions.
+  FileCheck
+  count
+  not
+  # Main tool for plugin testing.
+  opt
+  )
+
+if(NOT BUILD_EXTERNAL)
+  set(TEST_DEPS
+    ${USED_TOOLS}
+    )
+else()
+  # Check for tools availability.
+  foreach(tool ${USED_TOOLS})
+    set(TOOL_PATH "${LLVM_TOOLS_BINARY_DIR}/${tool}")
+    if(NOT EXISTS ${TOOL_PATH})
+      message(FATAL_ERROR "Tool ${tool} is not found (required by lit tests)")
+    endif()
+  endforeach()
+endif()
+
+# Add testsuite with custom config name that depends on generator.
+add_lit_testsuite(check-vc-intrinsics "Running the vc-intrinsics regression tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ARGS
+    "--config-prefix=vcint.$<CONFIG>.lit"
+    "-sv"
+  DEPENDS
+    ${TEST_DEPS}
+    VCIntrinsicsPlugin
+)

--- a/GenXIntrinsics/test/lit.cfg.py
+++ b/GenXIntrinsics/test/lit.cfg.py
@@ -1,0 +1,40 @@
+# -*- Python -*-
+
+import lit.formats
+import lit.util
+
+from lit.llvm import llvm_config
+from lit.llvm.subst import ToolSubst
+from lit.llvm.subst import FindTool
+
+# Configuration file for the 'lit' test runner.
+
+# name: The name of this test suite.
+config.name = 'vc-intrinsics'
+
+# testFormat: The test format to use to interpret tests.
+config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = ['.ll']
+
+# excludes: A list of directories  and files to exclude from the testsuite.
+config.excludes = ['CMakeLists.txt', 'Plugin']
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.test_run_dir, 'test_output')
+
+llvm_config.use_default_substitutions()
+
+config.substitutions.append(('%PATH%', config.environment['PATH']))
+
+tool_dirs = [config.llvm_tools_dir]
+
+# Add extra args for opt to remove boilerplate from tests.
+args_load_plugin = ['-load', config.vc_intrinsics_plugin]
+tools = [ToolSubst('opt', extra_args=args_load_plugin)]
+
+llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/GenXIntrinsics/test/lit.site.cfg.py.in
+++ b/GenXIntrinsics/test/lit.site.cfg.py.in
@@ -1,0 +1,29 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.llvm_src_root = "@LLVM_SOURCE_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
+config.host_triple = "@LLVM_HOST_TRIPLE@"
+config.target_triple = "@TARGET_TRIPLE@"
+config.host_arch = "@HOST_ARCH@"
+config.python_executable = "@PYTHON_EXECUTABLE@"
+config.test_run_dir = "@CMAKE_CURRENT_BINARY_DIR@"
+config.vc_intrinsics_plugin = "$<TARGET_FILE:VCIntrinsicsPlugin>"
+
+# Support substitution of the tools and libs dirs with user parameters. This is
+# used when we can't determine the tool dir at configuration time.
+try:
+    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@VC_INTRINSICS_TEST_SOURCE_DIR@/lit.cfg.py")


### PR DESCRIPTION
Add lit testing with dynamic LLVM configuration (both in-tree and
external). Use VC_INTR_ENABLE_LIT_TESTS cmake variable to control lit
tests. Add very simple test for spirv writer adaptor as example.