### PR TITLE
adding llvm.genx.output single argument analog llvm.genx.output.1

### DIFF
--- a/GenXIntrinsics/include/llvm/GenXIntrinsics/Intrinsic_definitions.py
+++ b/GenXIntrinsics/include/llvm/GenXIntrinsics/Intrinsic_definitions.py
@@ -3471,6 +3471,19 @@ Imported_Intrinsics = \
 ###
     "output" : ["void",["vararg"],"None"],
 
+### ``llvm.genx.output.1.<any type>`` : Mark output argument
+### ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+###
+### * Return value: void
+###
+### SPIRV does not support functions with variable-length argument number,
+### so output_1 is output analog with single argument
+### This implementation intrinsic is to mark output argument.
+### This intrinsic call only extends the live range of marked argument and
+### emits no code.
+###
+    "output_1" : ["void",["any"],"None"],
+
 ## ``llvm.genx.print.buffer`` : read stateless pointer to print buffer
 ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ## ``llvm.genx.print.buffer`` : read implicit arg print buffer ptr


### PR DESCRIPTION
We have this new mechanism to support FC API through SPIRV

SPIRV do not support var-arg instrinsics, so we are adding single-argument one