### PR TITLE
[NFC] Removing redundant default case on switch over an enum 

### DIFF
--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVReaderAdaptor.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVReaderAdaptor.cpp
@@ -249,9 +249,9 @@ static ArgKind mapSPIRVTypeToArgKind(SPIRVType Ty) {
   case SPIRVType::Other:
     return ArgKind::General;
   case SPIRVType::None:
-  default:
-    llvm_unreachable("Unexpected spirv type");
+    break;
   }
+  llvm_unreachable("Unexpected spirv type");
 }
 
 static std::string mapSPIRVDescToArgDesc(SPIRVArgDesc SPIRVDesc) {

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp
@@ -370,9 +370,8 @@ static SPIRVArgDesc analyzeArgumentAttributes(ArgKind Kind, StringRef Desc) {
     return analyzeSamplerArg(Desc);
   case ArgKind::Surface:
     return analyzeSurfaceArg(Desc);
-  default:
-    return {SPIRVType::None};
   }
+  return {SPIRVType::None};
 }
 
 // Extract ArgKind from VCArgumentKind attribute.


### PR DESCRIPTION
This is to fix the error in self build and following the the coding standard here: https://llvm.org/docs/CodingStandards.html#don-t-use-default-labels-in-fully-covered-switches-over-enumerations
