### PR TITLE
Add support for new PM in plugin and SPIRV writer adaptor

### DIFF
--- a/GenXIntrinsics/include/llvm/GenXIntrinsics/GenXSPIRVWriterAdaptor.h
+++ b/GenXIntrinsics/include/llvm/GenXIntrinsics/GenXSPIRVWriterAdaptor.h
@@ -23,14 +23,39 @@
 ======================= end_copyright_notice ==================================*/
 
 ///
-/// GenXSPIRVWriterAdaptor -- legacy PM version
+/// GenXSPIRVWriterAdaptor
 /// ---------------------------
 /// This pass converts metadata to SPIRV format from whichever used in frontend
+
+#include "llvm/IR/PassManager.h"
 
 namespace llvm {
 class ModulePass;
 class PassRegistry;
 
+//-----------------------------------------------------------------------------
+// New PM support
+//-----------------------------------------------------------------------------
+// Writer adaptor for new PM.
+class GenXSPIRVWriterAdaptor final
+    : public PassInfoMixin<GenXSPIRVWriterAdaptor> {
+  bool RewriteTypes = true;
+  bool RewriteSingleElementVectors = true;
+
+public:
+  GenXSPIRVWriterAdaptor(bool RewriteTypesIn,
+                         bool RewriteSingleElementVectorsIn)
+      : RewriteTypes(RewriteTypesIn),
+        RewriteSingleElementVectors(RewriteSingleElementVectorsIn) {}
+
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+
+  static StringRef getArgString() { return "GenXSPIRVWriterAdaptor"; }
+};
+
+//-----------------------------------------------------------------------------
+// Legacy PM support
+//-----------------------------------------------------------------------------
 void initializeGenXSPIRVWriterAdaptorLegacyPass(PassRegistry &);
 
 // Create spirv writer adaptor pass.

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp
@@ -599,7 +599,24 @@ bool GenXSPIRVWriterAdaptorImpl::runOnFunction(Function &F) {
   return true;
 }
 
-// Legacy PM support.
+//-----------------------------------------------------------------------------
+// New PM support
+//-----------------------------------------------------------------------------
+PreservedAnalyses llvm::GenXSPIRVWriterAdaptor::run(Module &M,
+                                                    ModuleAnalysisManager &) {
+  GenXSPIRVWriterAdaptorImpl Impl(RewriteTypes, RewriteSingleElementVectors);
+
+  if (!Impl.run(M))
+    return PreservedAnalyses::all();
+
+  PreservedAnalyses PA;
+  PA.preserveSet<CFGAnalyses>();
+  return PA;
+}
+
+//-----------------------------------------------------------------------------
+// Legacy PM support
+//-----------------------------------------------------------------------------
 namespace {
 class GenXSPIRVWriterAdaptorLegacy final : public ModulePass {
 public:
@@ -616,7 +633,7 @@ public:
         RewriteSingleElementVectors(RewriteSingleElementVectorsIn) {}
 
   llvm::StringRef getPassName() const override {
-    return "GenX SPIRVWriter Adaptor";
+    return GenXSPIRVWriterAdaptor::getArgString();
   }
   void getAnalysisUsage(AnalysisUsage &AU) const override;
   bool runOnModule(Module &M) override;
@@ -626,10 +643,9 @@ public:
 
 char GenXSPIRVWriterAdaptorLegacy::ID = 0;
 
-INITIALIZE_PASS_BEGIN(GenXSPIRVWriterAdaptorLegacy, "GenXSPIRVWriterAdaptor",
-                      "GenXSPIRVWriterAdaptor", false, false)
-INITIALIZE_PASS_END(GenXSPIRVWriterAdaptorLegacy, "GenXSPIRVWriterAdaptor",
-                    "GenXSPIRVWriterAdaptor", false, false)
+INITIALIZE_PASS(GenXSPIRVWriterAdaptorLegacy,
+                GenXSPIRVWriterAdaptor::getArgString(),
+                GenXSPIRVWriterAdaptor::getArgString(), false, false)
 
 ModulePass *
 llvm::createGenXSPIRVWriterAdaptorPass(bool RewriteTypes,

--- a/GenXIntrinsics/test/Adaptors/annot_mess_writer.ll
+++ b/GenXIntrinsics/test/Adaptors/annot_mess_writer.ll
@@ -1,4 +1,3 @@
-; XFAIL: llvm13
 ; Test messy annnotations translation in writer. First valid
 ; annotation should be matched.
 

--- a/GenXIntrinsics/test/Adaptors/annotated_args_no_conv_writer.ll
+++ b/GenXIntrinsics/test/Adaptors/annotated_args_no_conv_writer.ll
@@ -1,4 +1,3 @@
-; XFAIL: llvm13
 ; Test that writer does not changes signature if correct
 ; types are already used. Just drop all annotations.
 

--- a/GenXIntrinsics/test/Adaptors/annotated_args_writer.ll
+++ b/GenXIntrinsics/test/Adaptors/annotated_args_writer.ll
@@ -1,4 +1,3 @@
-; XFAIL: llvm13
 ; Test kernel arguments translation from old style with metadata to
 ; new style with opaque types that SPIRV translator can
 ; understand. Here annotations for OCL runtime are used.

--- a/GenXIntrinsics/test/Adaptors/combined_args_writer.ll
+++ b/GenXIntrinsics/test/Adaptors/combined_args_writer.ll
@@ -1,4 +1,3 @@
-; XFAIL: llvm13
 ; Test combined writer translation: kernel has both annotated explicit
 ; arguments and impicit arguments. Implicit arguments would not show
 ; in normal flow, though they appear in old cmc.

--- a/GenXIntrinsics/test/Adaptors/empty_kernel_writer.ll
+++ b/GenXIntrinsics/test/Adaptors/empty_kernel_writer.ll
@@ -1,4 +1,3 @@
-; XFAIL: llvm13
 ; Test empty kernel metadata translation: old -> new.
 
 ; RUN: opt -S -GenXSPIRVWriterAdaptor < %s | FileCheck %s

--- a/GenXIntrinsics/test/Adaptors/plain_args_writer.ll
+++ b/GenXIntrinsics/test/Adaptors/plain_args_writer.ll
@@ -1,4 +1,3 @@
-; XFAIL: llvm13
 ; Test kernel arguments translation from old style with metadata to
 ; new style with opaque types that SPIRV translator can
 ; understand. Arguments without annotations are used here (CMRT like).

--- a/GenXIntrinsics/test/Adaptors/sev_signature_writer.ll
+++ b/GenXIntrinsics/test/Adaptors/sev_signature_writer.ll
@@ -1,4 +1,3 @@
-; XFAIL: llvm13
 ; Test simple signatures tranform
 
 ; RUN: opt -S -GenXSPIRVWriterAdaptor < %s | FileCheck %s

--- a/GenXIntrinsics/test/Adaptors/surface_access_writer.ll
+++ b/GenXIntrinsics/test/Adaptors/surface_access_writer.ll
@@ -1,4 +1,3 @@
-; XFAIL: llvm13
 ; Test kernel surface argument translation from old style with
 ; metadata to new style with opaque types that SPIRV translator can
 ; understand. This test checks access qualifiers translation.

--- a/GenXIntrinsics/test/Adaptors/unknown_arg_writer.ll
+++ b/GenXIntrinsics/test/Adaptors/unknown_arg_writer.ll
@@ -1,4 +1,3 @@
-; XFAIL: llvm13
 ; Test writer translation of implicit argument. Implicit arguments
 ; should not appear in current form after transition from cmc.
 


### PR DESCRIPTION
Add wrapper for writer adaptor to integrate into new PM structure.
Reuse part of it in old wrapper. Add plugin infra for new PM and
handle writer adaptor.

Enable tests for writer adaptor for LLVM with new PM.