### PR TITLE
Fix Cmake Error

### DIFF
--- a/GenXIntrinsics/lib/GenXIntrinsics/CMakeLists.txt
+++ b/GenXIntrinsics/lib/GenXIntrinsics/CMakeLists.txt
@@ -49,6 +49,7 @@ else()
     GenXSPIRVReaderAdaptor.cpp
     GenXSPIRVWriterAdaptor.cpp
     GenXVersion.cpp
+    AdaptorsCommon.cpp
     ADDITIONAL_HEADER_DIRS
     ${GENX_INTRINSICS_MAIN_INCLUDE_DIR}/llvm/GenXIntrinsics
 


### PR DESCRIPTION
When building DPCPP compiler I saw the following error:

CMake Error at /llvm/cmake/modules/LLVMProcessSources.cmake:114 (message):
  Found unknown source file AdaptorsCommon.cpp