### PR TITLE
Stack calls are not necessary to be noinline

### DIFF
--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVReaderAdaptor.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVReaderAdaptor.cpp
@@ -562,7 +562,6 @@ bool GenXSPIRVReaderAdaptor::processVCFunctionAttributes(Function &F) {
 
   if (VCINTR::AttributeList::hasFnAttr(Attrs, VCFunctionMD::VCStackCall)) {
     F.addFnAttr(FunctionMD::CMStackCall);
-    F.addFnAttr(Attribute::NoInline);
     dropFnAttribute(F, VCFunctionMD::VCStackCall);
   }
 

--- a/GenXIntrinsics/test/Adaptors/fun_attributes_transform_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/fun_attributes_transform_reader.ll
@@ -48,7 +48,7 @@ define spir_kernel void @test_VCSLMSize() #6 {
   ret void
 }
 
-; CHECK-DAG: attributes #[[FATR_STACK_CALL_ATTR_IDX]] = { noinline "CMStackCall" }
+; CHECK-DAG: attributes #[[FATR_STACK_CALL_ATTR_IDX]] = { "CMStackCall" }
 ; CHECK-DAG: attributes #[[FATR_CALLABLE_ATTR_IDX]] = { "CMCallable" }
 ; CHECK-DAG: attributes #[[FATR_FC_ENTRY_IDX]] = { "CMEntry" }
 ; CHECK-DAG: attributes #[[FATR_SIMT_CALL_IDX]] = { "CMGenxSIMT" }


### PR DESCRIPTION
If the stack call must not be inlined, NoInline attribute should be
added by the FE, but not by the SPIRV reader adapter.