### PR TITLE
Fix lack of includes in GenXMetadata.h

### DIFF
--- a/GenXIntrinsics/include/llvm/GenXIntrinsics/GenXMetadata.h
+++ b/GenXIntrinsics/include/llvm/GenXIntrinsics/GenXMetadata.h
@@ -17,6 +17,10 @@ SPDX-License-Identifier: MIT
 #define GENX_METADATA_H
 
 namespace llvm {
+
+class MDNode;
+class Function;
+
 namespace genx {
 
 namespace FunctionMD {
@@ -68,22 +72,7 @@ enum KernelMDOp {
   BarrierCnt    // Barrier count
 };
 
-inline MDNode *GetOldStyleKernelMD(Function const &F) {
-  auto *KernelMD = static_cast<MDNode *>(nullptr);
-  auto *KernelMDs = F.getParent()->getNamedMetadata(FunctionMD::GenXKernels);
-  if (!KernelMDs)
-    return KernelMD;
-
-  for (unsigned I = 0, E = KernelMDs->getNumOperands(); I < E; ++I) {
-    auto *Kernel = mdconst::dyn_extract<Function>(
-        KernelMDs->getOperand(I)->getOperand(KernelMDOp::FunctionRef));
-    if (Kernel == &F) {
-      KernelMD = KernelMDs->getOperand(I);
-      break;
-    }
-  }
-  return KernelMD;
-}
+MDNode *GetOldStyleKernelMD(const Function &F);
 
 } // namespace genx
 } // namespace llvm

--- a/GenXIntrinsics/lib/GenXIntrinsics/CMakeLists.txt
+++ b/GenXIntrinsics/lib/GenXIntrinsics/CMakeLists.txt
@@ -23,6 +23,7 @@ if(BUILD_EXTERNAL)
               GenXSPIRVWriterAdaptor.cpp
               GenXVersion.cpp
               AdaptorsCommon.cpp
+              GenXMetadata.cpp
              )
   llvm_update_compile_flags(LLVMGenXIntrinsics)
   add_dependencies(LLVMGenXIntrinsics GenXIntrinsicsGen)
@@ -50,6 +51,7 @@ else()
     GenXSPIRVWriterAdaptor.cpp
     GenXVersion.cpp
     AdaptorsCommon.cpp
+    GenXMetadata.cpp
     ADDITIONAL_HEADER_DIRS
     ${GENX_INTRINSICS_MAIN_INCLUDE_DIR}/llvm/GenXIntrinsics
 

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXMetadata.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXMetadata.cpp
@@ -1,0 +1,32 @@
+/*========================== begin_copyright_notice ============================
+
+Copyright (C) 2021 Intel Corporation
+
+SPDX-License-Identifier: MIT
+
+============================= end_copyright_notice ===========================*/
+
+#include "llvm/GenXIntrinsics/GenXMetadata.h"
+
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Metadata.h>
+#include <llvm/IR/Module.h>
+
+using namespace llvm;
+
+MDNode *llvm::genx::GetOldStyleKernelMD(Function const &F) {
+  auto *KernelMD = static_cast<MDNode *>(nullptr);
+  auto *KernelMDs = F.getParent()->getNamedMetadata(FunctionMD::GenXKernels);
+  if (!KernelMDs)
+    return KernelMD;
+
+  for (unsigned I = 0, E = KernelMDs->getNumOperands(); I < E; ++I) {
+    auto *Kernel = mdconst::dyn_extract<Function>(
+        KernelMDs->getOperand(I)->getOperand(KernelMDOp::FunctionRef));
+    if (Kernel == &F) {
+      KernelMD = KernelMDs->getOperand(I);
+      break;
+    }
+  }
+  return KernelMD;
+}


### PR DESCRIPTION
GetOldStyleKernelMD implementation was moved out of the header.
Proper forward declarations were added.