### PR TITLE
Workaround for d116110 to get dpcpp compiler builds going.

### DIFF
--- a/GenXIntrinsics/include/llvmVCWrapper/IR/Attributes.h
+++ b/GenXIntrinsics/include/llvmVCWrapper/IR/Attributes.h
@@ -97,7 +97,7 @@ removeAttributeAtIndex(llvm::LLVMContext &C,
 inline llvm::AttributeList
 removeAttributesAtIndex(llvm::LLVMContext &C,
                         const llvm::AttributeList &AttrList, unsigned Index,
-                        const llvm::AttrBuilder &AttrsToRemove) {
+                        const llvm::AttributeMask &AttrsToRemove) {
 #if VC_INTR_LLVM_VERSION_MAJOR >= 14
   return AttrList.removeAttributesAtIndex(C, Index, AttrsToRemove);
 #else


### PR DESCRIPTION
Last argument to removeAttributesAtIndex was changed from AttrBuilder to
a newly added class AttributeMask.