### PR TITLE
 Fix buildfail on ToT caused by D116110

### DIFF
--- a/GenXIntrinsics/include/llvmVCWrapper/IR/Attributes.h
+++ b/GenXIntrinsics/include/llvmVCWrapper/IR/Attributes.h
@@ -94,17 +94,6 @@ removeAttributeAtIndex(llvm::LLVMContext &C,
 #endif
 }
 
-inline llvm::AttributeList
-removeAttributesAtIndex(llvm::LLVMContext &C,
-                        const llvm::AttributeList &AttrList, unsigned Index,
-                        const llvm::AttrBuilder &AttrsToRemove) {
-#if VC_INTR_LLVM_VERSION_MAJOR >= 14
-  return AttrList.removeAttributesAtIndex(C, Index, AttrsToRemove);
-#else
-  return AttrList.removeAttributes(C, Index, AttrsToRemove);
-#endif
-}
-
 } // namespace AttributeList
 
 } // namespace VCINTR


### PR DESCRIPTION
Remove unused wrapper to fix buildfail because of attribute removal
API change. New class was added in D116110 and wrapping of this case
is not trivial so removal of unneeded function is the easiest
solution.