### PR TITLE
1Squashed merge of master to dpcpp_staging aligning these

### DIFF
--- a/GenXIntrinsics/include/llvmVCWrapper/IR/Attributes.h
+++ b/GenXIntrinsics/include/llvmVCWrapper/IR/Attributes.h
@@ -94,17 +94,6 @@ removeAttributeAtIndex(llvm::LLVMContext &C,
 #endif
 }
 
-inline llvm::AttributeList
-removeAttributesAtIndex(llvm::LLVMContext &C,
-                        const llvm::AttributeList &AttrList, unsigned Index,
-                        const llvm::AttributeMask &AttrsToRemove) {
-#if VC_INTR_LLVM_VERSION_MAJOR >= 14
-  return AttrList.removeAttributesAtIndex(C, Index, AttrsToRemove);
-#else
-  return AttrList.removeAttributes(C, Index, AttrsToRemove);
-#endif
-}
-
 } // namespace AttributeList
 
 } // namespace VCINTR


### PR DESCRIPTION
Squashed commit of the following:

commit 3a5f4b4608f0e18fcdc04d851568f3aab4651545
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Tue Jan 11 12:23:57 2022 +0000

     Fix buildfail on ToT caused by D116110

    Remove unused wrapper to fix buildfail because of attribute removal
    API change. New class was added in D116110 and wrapping of this case
    is not trivial so removal of unneeded function is the easiest
    solution.

commit 753ad5002af5a5e467b3a0194a2b0e9a3243059e
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Thu Oct 7 10:41:10 2021 +0000

     Remove legacy simd8 intrinsics

    VC always uses simd1 mode with separate intrinsics.

commit 09ff7f80a6db1831de1ea5494a425184d490df1e
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Tue Oct 26 14:13:13 2021 +0000

     Remove wrappers for LLVM 7

    VC intrinsics no longer support LLVM 7.

commit 84308bec33fb1c15dd03c82f5c97145f3756add9
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Fri Oct 29 17:57:35 2021 +0000

     Provide cmake error when unsupported LLVM found

    Fail earlier on configuration stage.

commit d3cef33488b7d7a23dffe49aac42c2759b447dcf
Author: Dmitry Ryabtsev <dmitry.ryabtsev1@intel.com>
Date:   Thu Dec 9 15:49:28 2021 +0000

    Fix lack of includes in GenXMetadata.h

    GetOldStyleKernelMD implementation was moved out of the header.
    Proper forward declarations were added.

commit 381535d6c25c794adf164fae0d0cfdd6a18a09a5
Author: Anton Sidorenko <anton.sidorenko@intel.com>
Date:   Thu Dec 2 11:22:37 2021 +0000

    Stack calls are not necessary to be noinline

    If the stack call must not be inlined, NoInline attribute should be
    added by the FE, but not by the SPIRV reader adapter.

commit 8ee879314584e6630688b0a3b290d065dcabb383
Author: Konstantin Vladimirov <konstantin.vladimirov@intel.com>
Date:   Tue Nov 2 10:08:40 2021 +0000

    Introducing VC intrinsics interface for DG2 and PVC platforms

    A number of new intrinsics introduced

commit 4f460713c90662e20a56840d48466aeb18c9ef81
Author: DmitryBushev <dmitry.bushev@intel.com>
Date:   Tue Oct 12 15:08:20 2021 +0000

    Fixed SPIRVWriterAdaptor pass not adding attribute on address convert intrinsic

    SPIRVWriterAdaptor pass may add llvm.genx.address_convert intrinsics. Doing so
    it must explicitly add VCFunction attribute to newly created intrinsics.

commit c6e0c45edd7d8234ea271b0cbf11126dd5f3404b
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Wed Oct 27 21:36:00 2021 +0000

    Normalize ifs in cmake code

    Normalize ifs in cmake code

commit ed60a79bc552c1fb81b1e9251ba0d235237635cd
Author: Stanislav Sidelnikov <stanislav.sidelnikov@intel.com>
Date:   Mon Oct 25 11:19:30 2021 +0000

    Updating source files permissions

    Removed executuion bit in sources

commit d6d08b3b02af08ed4cd78029f5eee806ede657c7
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Tue Oct 19 13:00:16 2021 +0000

    Bump minimum supported LLVM version to 8

commit 6a7e93d3d90638b6565d97cef96ffaf0f77d688c
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Mon Oct 18 18:03:24 2021 +0000

    Wrap arg_size for call instructions

    Build fix after:
    https://reviews.llvm.org/rGb2ee408dde374d6a27a34746fd7c7b5bab97ea89

commit 2cd5a7b013d09d21ad206708943faf0b575e0ece
Author: Anatoly Parshintsev <anatoly.parshintsev@intel.com>
Date:   Thu Oct 7 12:25:27 2021 +0000

    introduce new RKL platform

commit 2140c91a241703d7d6c39d1b86e7684b2558d9d5
Author: Anatoly Parshintsev <anatoly.parshintsev@intel.com>
Date:   Fri Oct 1 14:36:09 2021 +0000

    spirv reader adaptor should discard redundant attributes

commit 9aafb518a05be160beffd7812a0f169c10786d04
Author: DmitryBushev <dmitry.bushev@intel.com>
Date:   Tue Sep 28 16:24:03 2021 +0000

    SPIRV-LLVM-Translator may convert native SPIRV types to 'SPIRV friendly IR' types
    defined in translator docs if dedicated option is passed. Adaptor should be able
    to read them as well as OCL types.

commit 465abdd6522b8e21b2c60ca2694bc8964a24c164
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Thu Sep 23 17:52:34 2021 +0000

    Add media block images to SPIRV adaptors

    Translate arguments annotated with "image2d_media_block_t" to special
    opaque type. New annotation is required to distinguish media block
    images and texture images.

commit 5c8159af873c96110c1b354f8660c044ff6b35b0
Author: Anatoly Parshintsev <anatoly.parshintsev@intel.com>
Date:   Sun Sep 26 06:19:09 2021 +0000

    Cleanup unnecessary/deprecated attributes from test

commit 085fcacac61e4012db8c7a175c43d7aa23f1911a
Author: DmitryBushev <dmitry.bushev@intel.com>
Date:   Tue Sep 7 17:07:27 2021 +0000

    In case there no kernels in module, SPIRV adaptor passes would skip proccessing
    of all functions that is not right

commit 5647df399355098aa5e8fe2c5c6bab2442533224
Author: Kirill Yansitov <kirill.yansitov@intel.com>
Date:   Mon Sep 13 12:29:38 2021 +0000

    Add 3rd argument for imad

commit 7a46e7e3ea7eef37cc1a77043fd1bf6a3cab1d9e
Author: Parshintsev Anatoly <anatoly.parshintsev@intel.com>
Date:   Fri Sep 10 23:54:05 2021 +0300

    More robust procedure to query availability of an intrinsic on a particular platform

commit 4e2a1cebbf5c47563d92785d04d8e0c614857a93
Author: Anatoly Parshintsev <anatoly.parshintsev@intel.com>
Date:   Wed Sep 8 23:02:41 2021 +0000

    synchornize platform list

commit e5ad7e02aa4aa21a3cd7b3e5d1f3ec9b95f58872
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Tue Sep 7 12:30:52 2021 +0000

    Add image array conversion in spirv adaptors

commit b1db3e55bac23670be4ffbd0da85a9fd0110f593
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Fri Sep 3 10:36:49 2021 +0000

    Wrap attribute at index methods

    Fix after https://reviews.llvm.org/D108614.

commit b66c5bbd66dc4a556fc624122d835552b3516f14
Author: Kirill Yansitov <kirill.yansitov@intel.com>
Date:   Tue Aug 31 16:22:22 2021 +0000

    Add intrinsics to represent cm_imul builtin
    This intrinsic doesn't produce vISA instr and must be lower in backend
    Small fixes in madw description to allow only width equal 2GRF/sizeof(i32)

commit 006d176f31b4ebf5e2c2ad8befb8d0227112bb0a
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Fri Aug 20 13:12:43 2021 +0000

    Remove odd specifiers from functions in headers

    Remove static from inline functions in headers. Remove inline from
    in-class static function definitions. Replace static with inline for
    functions in wrapper headers.

commit a2f2f10dc61c8161c57cf33ed606c8e3ccf3a921
Author: DenisBakhvalov <61807338+DenisBakhvalov@users.noreply.github.com>
Date:   Thu Aug 19 15:58:05 2021 -0700

    Fix Cmake Error

    When building DPCPP compiler I saw the following error:

    CMake Error at /llvm/cmake/modules/LLVMProcessSources.cmake:114 (message):
      Found unknown source file AdaptorsCommon.cpp

commit 6221091b0a6b97c9bd9147d03ad09fbe74b8d89f
Author: Dmitry Bushev <dmitry.bushev@intel.com>
Date:   Thu Aug 19 16:42:01 2021 +0300

    Fix llvm verifier assertion

    SPIRVAdaptor passes didn't properly handle the pointer attributes when rewiting
    types in kernel signature leading to module verification failure

commit 2bbb573f4030c3006031a585b2ab2b027fe0a507
Author: Bargatin-Intel <mikhail.bargatin@intel.com>
Date:   Wed Aug 18 13:42:58 2021 +0300

    Add missing header

commit fd9bf4b3a91f853ed74a376df58123bb75f64449
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Mon Aug 16 13:28:05 2021 +0000

    Wrap AttributeList::hasFnAttr

    Fix intrinsics build after
    https://reviews.llvm.org/rG92ce6db9ee7666a347fccf0f72ba3225b199d6d1

commit 90113a56d0f0b67b268d55e685dc3c00dad9e3a0
Author: Kirill Yansitov <kirill.yansitov@intel.com>
Date:   Fri Jul 30 21:26:25 2021 +0000

    add intrinsic to represent visa madw instr

commit 4e3870da11247096c1d2524e858bd2ae3df5175d
Author: Dmitriy Drozdov <dmitriy.drozdov@intel.com>
Date:   Thu Jul 29 09:47:33 2021 +0000

    Revert "Introduce new vc intrinsic to access timestamp register"

commit 0bf761ef358d70b5a27292845f0def764aeb8a7f
Author: Dmitriy Drozdov <dmitriy.drozdov@intel.com>
Date:   Thu Jul 29 16:29:49 2021 +0000

    Mark lit tests as XFAIL for llvm 14 (tot)

commit 05d3f3d2b9ae59d32893976e0e76415fec1108b9
Author: Nikita Rudenko <nikita.rudenko@intel.com>
Date:   Thu Jun 24 14:54:03 2021 +0000

    Add global variables support to GenXSingleElementVector pass

commit 43b1af8933c75c045c7d5e659bf98eaa57811071
Author: Nikita Rudenko <nikita.rudenko@intel.com>
Date:   Tue Jul 27 12:36:20 2021 +0000

    Fix typo in GenXIntrinsics/CMakeLists.txt

commit 185f382cc9d564d34c3cb9452762e496f43d3fd7
Author: lgotszal <lukasz.gotszald@intel.com>
Date:   Thu Jul 22 07:43:26 2021 +0000

    update copyright headers
    update Python copyright to PEP8 style

commit 63cbfe0b0d68fa0c2d66b8a4a676c2bb3f01facf
Author: lgotszal <lukasz.gotszald@intel.com>
Date:   Tue Jul 6 10:55:54 2021 +0000

    update MIT copyright headers

commit f45e04c6aa293d04da97f902aa9aa766a525e017
Author: Dmitriy Drozdov <dmitriy.drozdov@intel.com>
Date:   Tue Jul 20 15:15:02 2021 +0000

    Introduce new vc intrinsic to access timestamp register