### PR TITLE
 Fix an issue with GenXIntrinsicDescription.gen includes

### DIFF
--- a/GenXIntrinsics/include/llvm/GenXIntrinsics/GenXSimdCFLowering.h
+++ b/GenXIntrinsics/include/llvm/GenXIntrinsics/GenXSimdCFLowering.h
@@ -17,6 +17,7 @@ SPDX-License-Identifier: MIT
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Instructions.h"
 #include <algorithm>
+#include <map>
 #include <set>
 
 namespace llvm {

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp
@@ -35,6 +35,7 @@ See LICENSE.TXT for details.
 #include "llvmVCWrapper/IR/Intrinsics.h"
 
 #include <cstring>
+#include <map>
 
 using namespace llvm;
 


### PR DESCRIPTION
Fix an issue where GenXIntrinsicDescription.gen is included without
including map header.