### PR TITLE
Rebasing dpcpp_staging branch to current master

### DIFF
--- a/GenXIntrinsics/CMakeLists.txt
+++ b/GenXIntrinsics/CMakeLists.txt
@@ -75,9 +75,16 @@ if(INSTALL_REQUIRED)
       INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 
+    # Legacy export. To remove when all clients switch to new name.
     install(EXPORT LLVMGenXIntrinsicsTargets
       FILE LLVMGenXIntrinsicsConfig.cmake
       DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LLVMGenXIntrinsics
+    )
+
+    set(PACKAGE_NAME VCIntrinsics${LLVM_VERSION_MAJOR})
+    install(EXPORT LLVMGenXIntrinsicsTargets
+      FILE ${PACKAGE_NAME}Config.cmake
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PACKAGE_NAME}
     )
   endif() # BUILD_EXTERNAL
 endif() # INSTALL_REQUIRED

--- a/GenXIntrinsics/include/llvm/GenXIntrinsics/Intrinsic_definitions.py
+++ b/GenXIntrinsics/include/llvm/GenXIntrinsics/Intrinsic_definitions.py
@@ -1775,6 +1775,21 @@ Imported_Intrinsics = \
                      "attributes" : "NoMem"
                    },
 
+### add3c
+### ^^^^^
+###
+### ``llvm.genx.add3c.<{carry, add3}>.<any int>`` : add3 with carry
+### ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+### * ``llvm.genx.add3c`` :
+###
+### * arg0: first input, i32 scalar/vector integer type
+### * arg1: second input, same type as arg0
+### * arg2: third input, same type as arg0
+    "add3c" : { "result" : ["anyint", "intvector"],
+                "arguments" :  ["anyint",1,1,1],
+                "attributes" :  "NoMem"
+              },
+
 ### bfn
 ### ^^^
 ###
@@ -1885,10 +1900,11 @@ Imported_Intrinsics = \
 ###
 ###   - 0 -> .df (default)
 ###   - 1 -> .uc (uncached)
-###   - 2 -> .wb (writeback)
-###   - 3 -> .wt (writethrough)
-###   - 4 -> .st (streaming)
-###   - 5 -> .ri (read-invalidate)
+###   - 2 -> .ca (cached)
+###   - 3 -> .wb (writeback)
+###   - 4 -> .wt (writethrough)
+###   - 5 -> .st (streaming)
+###   - 6 -> .ri (read-invalidate)
 ###
 ### Only certain combinations of CachingL1 with CachingL3 are valid on hardware.
 ###
@@ -1897,19 +1913,19 @@ Imported_Intrinsics = \
 ### +---------+-----+-----------------------------------------------------------------------+
 ### | .df     | .df | default behavior on both L1 and L3 (L3 uses MOCS settings)            |
 ### +---------+-----+-----------------------------------------------------------------------+
-### | .ri/.wb | .wb | read-invalidate on reads (e.g. last use) / writeback on Stores for L1 |
-### +---------+-----+-----------------------------------------------------------------------+
 ### | .uc     | .uc | uncached (bypass) both L1 and L3                                      |
-### +---------+-----+-----------------------------------------------------------------------+
-### | .uc     | .wb | bypass L1 / writeback L3                                              |
-### +---------+-----+-----------------------------------------------------------------------+
-### | .wt     | .uc | writethrough L1 / bypass L3                                           |
-### +---------+-----+-----------------------------------------------------------------------+
-### | .wt     | .wb | writethrough L1 / writeback L3                                        |
 ### +---------+-----+-----------------------------------------------------------------------+
 ### | .st     | .uc | streaming L1 / bypass L3                                              |
 ### +---------+-----+-----------------------------------------------------------------------+
-### | .st     | .wb | streaming L1 / writeback L3                                           |
+### | .uc     | .ca | bypass L1 / cache in L3                                               |
+### +---------+-----+-----------------------------------------------------------------------+
+### | .ca     | .uc | cache in L1 / bypass L3                                               |
+### +---------+-----+-----------------------------------------------------------------------+
+### | .ca     | .ca | cache in both L1 and L3                                               |
+### +---------+-----+-----------------------------------------------------------------------+
+### | .st     | .ca | streaming L1 / cache in L3                                            |
+### +---------+-----+-----------------------------------------------------------------------+
+### | .ri     | .ca | read-invalidate (e.g. last-use) on L1 loads / cache in L3             |
 ### +---------+-----+-----------------------------------------------------------------------+
 ###
 ### Immediate offset. The compiler may be able to fuse this add into the message, otherwise
@@ -1999,6 +2015,38 @@ Imported_Intrinsics = \
 ###          for flat and bindless version pass zero here
 ###
 ### * Return value: void
+###
+### Cache mappings are:
+###
+###   - 0 -> .df (default)
+###   - 1 -> .uc (uncached)
+###   - 2 -> .ca (cached)
+###   - 3 -> .wb (writeback)
+###   - 4 -> .wt (writethrough)
+###   - 5 -> .st (streaming)
+###   - 6 -> .ri (read-invalidate)
+###
+### Only certain combinations of CachingL1 with CachingL3 are valid on hardware.
+###
+### +---------+-----+-----------------------------------------------------------------------+
+### |  L1     |  L3 | Notes                                                                 |
+### +---------+-----+-----------------------------------------------------------------------+
+### | .df     | .df | default behavior on both L1 and L3 (L3 uses MOCS settings)            |
+### +---------+-----+-----------------------------------------------------------------------+
+### | .uc     | .uc | uncached (bypass) both L1 and L3                                      |
+### +---------+-----+-----------------------------------------------------------------------+
+### | .st     | .uc | streaming L1 / bypass L3                                              |
+### +---------+-----+-----------------------------------------------------------------------+
+### | .uc     | .wb | bypass L1/ writeback L3                                               |
+### +---------+-----+-----------------------------------------------------------------------+
+### | .wt     | .uc | writethrough L1 / bypass L3                                           |
+### +---------+-----+-----------------------------------------------------------------------+
+### | .wt     | .wb | writethrough L1 / writeback L3                                        |
+### +---------+-----+-----------------------------------------------------------------------+
+### | .st     | .wb | streaming L1 / writeback L3                                           |
+### +---------+-----+-----------------------------------------------------------------------+
+### | .wb     | .wb | writeback both L1 and L3                                              |
+### +---------+-----+-----------------------------------------------------------------------+
 ###
     "lsc_store_slm" : { "result" : "void",
                         "arguments" : ["any","char","char","char","short","int","char","char","char","char","any","anyvector","int"],
@@ -5374,4 +5422,14 @@ Imported_Intrinsics = \
                 "arguments" : ["anyint", 1, 1],
                 "attributes" : "NoMem"
               },
+
+### ``llvm.genx.slm.init`` : slm_init instruction
+### ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+###
+### * arg0: slm size, i32 scalar integer type
+###
+    "slm_init" : { "result" : "void",
+                   "arguments" : ["int"],
+                   "attributes" : "None"
+                 },
 }

--- a/GenXIntrinsics/include/llvm/GenXIntrinsics/Intrinsics.py
+++ b/GenXIntrinsics/include/llvm/GenXIntrinsics/Intrinsics.py
@@ -78,9 +78,28 @@ attribute_map = {
 
 # order does really matter.
 # It is used to define ordering between the respected platforms
-platform_list = ["HSW", "BDW", "CHV", "SKL", "BXT", "KBL",
-        "GLK", "CNL", "ICL", "ICLLP", "TGLLP", "RKL", "DG1",
-        "XEHP", "DG2", "PVC", "PVCXT"]
+platform_list = [
+    "HSW",
+    "BDW",
+    "CHV",
+    "SKL",
+    "BXT",
+    "KBL",
+    "GLK",
+    "CNL",
+    "ICL",
+    "ICLLP",
+    "TGLLP",
+    "RKL",
+    "DG1",
+    "ADLP",
+    "ADLS",
+    "XEHP",
+    "DG2",
+    "PVC",
+    "PVCXT_A0",
+    "PVCXT",
+]
 
 def getAttributeList(Attrs):
     """

--- a/GenXIntrinsics/lib/GenXIntrinsics/AdaptorsCommon.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/AdaptorsCommon.cpp
@@ -43,7 +43,7 @@ void legalizeParamAttributes(Function *F) {
       continue;
 #endif // VC_INTR_LLVM_VERSION_MAJOR >= 13
 
-    auto *ElemType = PTy->getElementType();
+    auto *ElemType = PTy->getPointerElementType();
 
     legalizeAttribute(Arg, ElemType, Attribute::ByVal);
 

--- a/GenXIntrinsics/lib/GenXIntrinsics/CMakeLists.txt
+++ b/GenXIntrinsics/lib/GenXIntrinsics/CMakeLists.txt
@@ -13,29 +13,25 @@ set(LLVM_COMPONENTS
   Analysis
   )
 
+set(SRC_LIST
+  GenXIntrinsics.cpp
+  GenXRestoreIntrAttr.cpp
+  GenXSimdCFLowering.cpp
+  GenXSingleElementVectorUtil.cpp
+  GenXSPIRVReaderAdaptor.cpp
+  GenXSPIRVWriterAdaptor.cpp
+  GenXVersion.cpp
+  AdaptorsCommon.cpp
+  GenXMetadata.cpp
+)
+
 if(BUILD_EXTERNAL)
-  add_library(LLVMGenXIntrinsics 
-              GenXIntrinsics.cpp
-              GenXRestoreIntrAttr.cpp
-              GenXSimdCFLowering.cpp
-              GenXSingleElementVectorUtil.cpp
-              GenXSPIRVReaderAdaptor.cpp
-              GenXSPIRVWriterAdaptor.cpp
-              GenXVersion.cpp
-              AdaptorsCommon.cpp
-              GenXMetadata.cpp
-             )
+  add_library(LLVMGenXIntrinsics ${SRC_LIST})
   llvm_update_compile_flags(LLVMGenXIntrinsics)
   add_dependencies(LLVMGenXIntrinsics GenXIntrinsicsGen)
 
   vc_get_llvm_targets(LLVM_LIBS ${LLVM_COMPONENTS})
   target_link_libraries(LLVMGenXIntrinsics ${LLVM_LIBS})
-
-  target_include_directories(LLVMGenXIntrinsics PUBLIC
-    $<BUILD_INTERFACE:${GENX_INTRINSICS_MAIN_INCLUDE_DIR}>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../../include>
-    $<INSTALL_INTERFACE:include>
-  )
 else()
   # when we are building in LLVM infra, we need to conform
   set(LLVM_LINK_COMPONENTS
@@ -43,20 +39,18 @@ else()
     )
 
   add_llvm_library(LLVMGenXIntrinsics
-    GenXIntrinsics.cpp
-    GenXRestoreIntrAttr.cpp
-    GenXSimdCFLowering.cpp
-    GenXSingleElementVectorUtil.cpp
-    GenXSPIRVReaderAdaptor.cpp
-    GenXSPIRVWriterAdaptor.cpp
-    GenXVersion.cpp
-    AdaptorsCommon.cpp
-    GenXMetadata.cpp
-    ADDITIONAL_HEADER_DIRS
-    ${GENX_INTRINSICS_MAIN_INCLUDE_DIR}/llvm/GenXIntrinsics
+    ${SRC_LIST}
 
+    ADDITIONAL_HEADER_DIRS
+      ${GENX_INTRINSICS_MAIN_INCLUDE_DIR}/llvm/GenXIntrinsics
     DEPENDS
       GenXIntrinsicsGen
       intrinsics_gen
   )
 endif()
+
+target_include_directories(LLVMGenXIntrinsics PUBLIC
+  $<BUILD_INTERFACE:${GENX_INTRINSICS_MAIN_INCLUDE_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../../include>
+  $<INSTALL_INTERFACE:include>
+  )

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp
@@ -412,7 +412,7 @@ static std::string getMangledTypeStr(Type* Ty) {
   std::string Result;
   if (PointerType* PTyp = dyn_cast<PointerType>(Ty)) {
     Result += "p" + llvm::utostr(PTyp->getAddressSpace()) +
-      getMangledTypeStr(PTyp->getElementType());
+      getMangledTypeStr(PTyp->getPointerElementType());
   } else if (ArrayType* ATyp = dyn_cast<ArrayType>(Ty)) {
     Result += "a" + llvm::utostr(ATyp->getNumElements()) +
       getMangledTypeStr(ATyp->getElementType());
@@ -688,93 +688,40 @@ std::string GenXIntrinsic::getAnyName(unsigned id, ArrayRef<Type *> Tys) {
 GenXIntrinsic::LSCVectorSize GenXIntrinsic::getLSCVectorSize(
     const Instruction *I) {
   assert(isLSC(I));
-  switch (getLSCCategory(I)) {
-    case LSCCategory::Load:
-    case LSCCategory::Prefetch:
-    case LSCCategory::Store:
-    case LSCCategory::Atomic:
-      return static_cast<LSCVectorSize>(
-          cast<ConstantInt>(I->getOperand(7))->getZExtValue());
-    case LSCCategory::LegacyAtomic:
-      return static_cast<LSCVectorSize>(
-          cast<ConstantInt>(I->getOperand(8))->getZExtValue());
-    case LSCCategory::Fence:
-    case LSCCategory::Load2D:
-    case LSCCategory::Prefetch2D:
-    case LSCCategory::Store2D:
-    case LSCCategory::NotLSC:
-      return LSCVectorSize::N0;
-  }
-  llvm_unreachable("Unknown LSC category");
+  const int VectorSizeIdx = LSCArgIdx::getLSCVectorSize(getLSCCategory(I));
+  if (VectorSizeIdx == LSCArgIdx::Invalid)
+    return LSCVectorSize::N0;
+  return static_cast<LSCVectorSize>(
+      cast<ConstantInt>(I->getOperand(VectorSizeIdx))->getZExtValue());
 }
 
 GenXIntrinsic::LSCDataSize GenXIntrinsic::getLSCDataSize(
     const Instruction *I) {
   assert(isLSC(I));
-  switch (getLSCCategory(I)) {
-    case LSCCategory::Load:
-    case LSCCategory::Prefetch:
-    case LSCCategory::Store:
-    case LSCCategory::LegacyAtomic:
-    case LSCCategory::Atomic:
-      return static_cast<LSCDataSize>(
-          cast<ConstantInt>(I->getOperand(6))->getZExtValue());
-    case LSCCategory::Load2D:
-    case LSCCategory::Prefetch2D:
-    case LSCCategory::Store2D:
-      return static_cast<LSCDataSize>(
-          cast<ConstantInt>(I->getOperand(3))->getZExtValue());
-    case LSCCategory::Fence:
-    case LSCCategory::NotLSC:
-      return LSCDataSize::Invalid;
-  }
-  llvm_unreachable("Unknown LSC category");
+  const int DataSizeIdx = LSCArgIdx::getLSCDataSize(getLSCCategory(I));
+  if (DataSizeIdx == LSCArgIdx::Invalid)
+    return LSCDataSize::Invalid;
+  return static_cast<LSCDataSize>(
+      cast<ConstantInt>(I->getOperand(DataSizeIdx))->getZExtValue());
 }
 
 GenXIntrinsic::LSCDataOrder GenXIntrinsic::getLSCDataOrder(
     const Instruction *I) {
   assert(isLSC(I));
-  switch (getLSCCategory(I)) {
-    case LSCCategory::Load:
-    case LSCCategory::Prefetch:
-    case LSCCategory::Store:
-    case LSCCategory::Atomic:
-      return static_cast<LSCDataOrder>(
-          cast<ConstantInt>(I->getOperand(8))->getZExtValue());
-    case LSCCategory::LegacyAtomic:
-      return static_cast<LSCDataOrder>(
-          cast<ConstantInt>(I->getOperand(7))->getZExtValue());
-    case LSCCategory::Load2D:
-    case LSCCategory::Prefetch2D:
-    case LSCCategory::Store2D:
-      return static_cast<LSCDataOrder>(
-          cast<ConstantInt>(I->getOperand(4))->getZExtValue());
-    case LSCCategory::Fence:
-    case LSCCategory::NotLSC:
-      return LSCDataOrder::Invalid;
-  }
-  llvm_unreachable("Unknown LSC category");
+  const int DataOrderIdx = LSCArgIdx::getLSCDataOrder(getLSCCategory(I));
+  if (DataOrderIdx == LSCArgIdx::Invalid)
+    return LSCDataOrder::Invalid;
+  return static_cast<LSCDataOrder>(
+      cast<ConstantInt>(I->getOperand(DataOrderIdx))->getZExtValue());
 }
 
 unsigned GenXIntrinsic::getLSCWidth(const Instruction *I) {
   assert(isLSC(I));
-  switch(getLSCCategory(I)) {
-    case LSCCategory::Load:
-    case LSCCategory::Prefetch:
-    case LSCCategory::Store:
-    case LSCCategory::Fence:
-    case LSCCategory::LegacyAtomic:
-    case LSCCategory::Atomic: {
-    case LSCCategory::Prefetch2D:
-      if (auto VT = dyn_cast<VectorType>(I->getOperand(0)->getType()))
-        return VCINTR::VectorType::getNumElements(VT);
-      return 1;
-    }
-    case LSCCategory::Load2D:
-    case LSCCategory::Store2D:
-    case LSCCategory::NotLSC:
-      return 1;
-  }
-  llvm_unreachable("Unknown LSC category");
+  const int WidthIdx = LSCArgIdx::getLSCWidth(getLSCCategory(I));
+  if (WidthIdx == LSCArgIdx::Invalid)
+    return 1;
+  if (auto VT = dyn_cast<VectorType>(I->getOperand(WidthIdx)->getType()))
+    return VCINTR::VectorType::getNumElements(VT);
+  return 1;
 }
 

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXRestoreIntrAttr.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXRestoreIntrAttr.cpp
@@ -27,12 +27,12 @@ See LICENSE.TXT for details.
 ///
 //===----------------------------------------------------------------------===//
 
-#define DEBUG_TYPE "GENX_RESTOREINTRATTR"
-
 #include "llvm/GenXIntrinsics/GenXIntrOpts.h"
 #include "llvm/GenXIntrinsics/GenXIntrinsics.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Pass.h"
+
+#define DEBUG_TYPE "GENX_RESTOREINTRATTR"
 
 using namespace llvm;
 

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVReaderAdaptor.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVReaderAdaptor.cpp
@@ -294,7 +294,7 @@ static SPIRVArgDesc analyzeKernelArg(const Argument &Arg) {
       AddressSpace != SPIRVParams::SPIRVConstantAS)
     return {SPIRVType::Other};
 
-  Type *PointeeTy = PointerTy->getElementType();
+  Type *PointeeTy = PointerTy->getPointerElementType();
   // Not a pointer to struct, cannot be sampler or image.
   if (!isa<StructType>(PointeeTy))
     return {SPIRVType::Pointer};
@@ -601,7 +601,7 @@ bool GenXSPIRVReaderAdaptor::processVCFunctionAttributes(Function &F) {
   if (auto *ReqdSubgroupSize =
           F.getMetadata(SPIRVParams::SPIRVSIMDSubgroupSize)) {
     auto SIMDSize =
-        mdconst::dyn_extract<ConstantInt>(ReqdSubgroupSize->getOperand(0))
+        mdconst::extract<ConstantInt>(ReqdSubgroupSize->getOperand(0))
             ->getZExtValue();
     Attribute Attr = Attribute::get(Context, FunctionMD::OCLRuntime,
                                     std::to_string(SIMDSize));

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp
@@ -610,6 +610,18 @@ bool GenXSPIRVWriterAdaptorImpl::runOnFunction(Function &F) {
     }
   }
 
+  if (KernelMD->getNumOperands() > KernelMDOp::NBarrierCnt) {
+    if (auto VM = dyn_cast<ValueAsMetadata>(
+            KernelMD->getOperand(KernelMDOp::NBarrierCnt)))
+      if (auto V = dyn_cast<ConstantInt>(VM->getValue())) {
+        auto NBarrierCnt = V->getZExtValue();
+        auto Attr = Attribute::get(Context, VCFunctionMD::VCNamedBarrierCount,
+                                   std::to_string(NBarrierCnt));
+        VCINTR::Function::addAttributeAtIndex(F, AttributeList::FunctionIndex,
+                                              Attr);
+      }
+  }
+
   return true;
 }
 

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXSimdCFLowering.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXSimdCFLowering.cpp
@@ -149,8 +149,6 @@ SPDX-License-Identifier: MIT
 ///
 //===----------------------------------------------------------------------===//
 
-#define DEBUG_TYPE "cmsimdcflowering"
-
 #include "llvm/GenXIntrinsics/GenXSimdCFLowering.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/Analysis/PostDominators.h"
@@ -175,6 +173,8 @@ SPDX-License-Identifier: MIT
 #include <set>
 
 #include "llvmVCWrapper/IR/DerivedTypes.h"
+
+#define DEBUG_TYPE "cmsimdcflowering"
 
 using namespace llvm;
 
@@ -362,7 +362,7 @@ bool CMSimdCFLowering::doInitialization(Module &M)
         auto AS1 = LI->getPointerAddressSpace();
         if (AS1 != AS0) {
           auto PtrTy = cast<PointerType>(Ptr->getType());
-          PtrTy = PointerType::get(PtrTy->getElementType(), AS0);
+          PtrTy = PointerType::get(PtrTy->getPointerElementType(), AS0);
           Ptr = Builder.CreateAddrSpaceCast(Ptr, PtrTy);
         }
         Type* Tys[] = { LI->getType(), Ptr->getType() };
@@ -379,7 +379,7 @@ bool CMSimdCFLowering::doInitialization(Module &M)
         auto AS1 = SI->getPointerAddressSpace();
         if (AS1 != AS0) {
           auto PtrTy = cast<PointerType>(Ptr->getType());
-          PtrTy = PointerType::get(PtrTy->getElementType(), AS0);
+          PtrTy = PointerType::get(PtrTy->getPointerElementType(), AS0);
           Ptr = Builder.CreateAddrSpaceCast(Ptr, PtrTy);
         }
         Type* Tys[] = { SI->getValueOperand()->getType(), Ptr->getType() };

--- a/GenXIntrinsics/test/Adaptors/annotated_args_mixed_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/annotated_args_mixed_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test that reader can cope with mixed mode when some
 ; arguments use address convert and some do not.
 

--- a/GenXIntrinsics/test/Adaptors/annotated_args_no_conv_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/annotated_args_no_conv_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test that reader correctly restores metadata and does
 ; not change other things if there is no address conversion
 ; but correct SPIRV types in signature.

--- a/GenXIntrinsics/test/Adaptors/annotated_args_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/annotated_args_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test kernel argument translation from new style with opaque types
 ; that SPIRV translator can understand to old style with
 ; metadata. Here annotations for OCL runtime are used.

--- a/GenXIntrinsics/test/Adaptors/args_attributes_transform_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/args_attributes_transform_reader.ll
@@ -9,7 +9,7 @@
 ; Test that adaptor correctly handles parameter attributes with types.
 
 ; UNSUPPORTED: llvm8
-; XFAIL: llvm13, llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; RUN: opt -S -GenXSPIRVReaderAdaptor < %s | FileCheck %s
 ; CHECK: @test
 ; CHECK-SAME: (%foo addrspace(1)* byval(%foo) %arg)

--- a/GenXIntrinsics/test/Adaptors/combined_args_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/combined_args_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test combined reader translation: kernel has both native SPIRV types
 ; and impicit arguments. Implicit arguments would not show in normal
 ; flow, though they appear in old cmc.

--- a/GenXIntrinsics/test/Adaptors/fun_attributes_transform_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/fun_attributes_transform_reader.ll
@@ -10,7 +10,7 @@
 ; metadata (the processed attributes are expected to be discarded)
 
 ; UNSUPPORTED: llvm8
-; XFAIL: llvm13, llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; RUN: opt -S -GenXSPIRVReaderAdaptor < %s | FileCheck %s
 ; CHECK: @test_VCFunction()
 ; CHECK: @test_VCStackCall()

--- a/GenXIntrinsics/test/Adaptors/image_array_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/image_array_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test reader translation of image array arguments.
 
 ; RUN: opt -S -GenXSPIRVReaderAdaptor < %s | FileCheck %s

--- a/GenXIntrinsics/test/Adaptors/media_block_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/media_block_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test reader translation of media block image arguments.
 
 ; RUN: opt -S -GenXSPIRVReaderAdaptor < %s | FileCheck %s

--- a/GenXIntrinsics/test/Adaptors/no_kernels_module_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/no_kernels_module_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test general translation of attributes within module that has no kernels
 
 ; RUN: opt -S -GenXSPIRVReaderAdaptor < %s | FileCheck %s

--- a/GenXIntrinsics/test/Adaptors/no_vcfunction_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/no_vcfunction_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test that reader ignores signature rewriting for kernels
 ; that are not VCFunction.
 

--- a/GenXIntrinsics/test/Adaptors/non_global_ptr_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/non_global_ptr_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test that reader treats only global pointer as svmptr type
 ; and ignores other address spaces.
 

--- a/GenXIntrinsics/test/Adaptors/old_decorated_args_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/old_decorated_args_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test reader translation of old-style decorated arguments.
 ; Annotations for these are directly translated from attributes to
 ; kernel metadata without any checks. Required until full transition

--- a/GenXIntrinsics/test/Adaptors/plain_args_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/plain_args_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test kernel argument translation from new style with opaque types
 ; that SPIRV translator can understand to old style with
 ; metadata. Arguments without annotations are used here (CMRT like).

--- a/GenXIntrinsics/test/Adaptors/sev_calling_conv_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/sev_calling_conv_reader.ll
@@ -1,0 +1,37 @@
+;=========================== begin_copyright_notice ============================
+;
+; Copyright (C) 2022 Intel Corporation
+;
+; SPDX-License-Identifier: MIT
+;
+;============================ end_copyright_notice =============================
+
+; Test GenXSingleElementVectorUtil preserves calling convention
+; (spir_func here)
+
+; XFAIL: llvm13, llvm14, llvm15
+; RUN: opt -S -GenXSPIRVReaderAdaptor < %s | FileCheck %s
+
+
+; ModuleID = 'start.ll'
+source_filename = "start.ll"
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: noinline nounwind
+; CHECK: define internal spir_func void @bar(<1 x i32>* %a) #0 {
+define internal spir_func void @bar(i32* "VCSingleElementVector"="0" %a) #0 {
+  ret void
+}
+
+; Function Attrs: noinline nounwind
+define spir_kernel void @foo() #1 !intel_reqd_sub_group_size !0 {
+; CHECK: call spir_func void @bar(<1 x i32>* undef)
+  call spir_func void @bar(i32* undef)
+  ret void
+}
+
+attributes #0 = { noinline nounwind "VCFunction" }
+attributes #1 = { noinline nounwind "VCFunction" "VCNamedBarrierCount"="0" "VCSLMSize"="0" }
+
+!0 = !{i32 1}

--- a/GenXIntrinsics/test/Adaptors/sev_calling_conv_writer.ll
+++ b/GenXIntrinsics/test/Adaptors/sev_calling_conv_writer.ll
@@ -1,0 +1,39 @@
+;=========================== begin_copyright_notice ============================
+;
+; Copyright (C) 2022 Intel Corporation
+;
+; SPDX-License-Identifier: MIT
+;
+;============================ end_copyright_notice =============================
+
+; Test GenXSingleElementVectorUtil preserves calling convention
+; (spir_func here)
+
+; RUN: opt -S -GenXSPIRVWriterAdaptor < %s | FileCheck %s
+
+; ModuleID = 'sev_calling_conv_reader.ll'
+source_filename = "start.ll"
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: noinline nounwind
+; CHECK: define internal spir_func void @bar(i32* "VCSingleElementVector"="0" %a) #0
+define internal spir_func void @bar(<1 x i32>* %a) #0 {
+  ret void
+}
+
+; Function Attrs: noinline nounwind
+define dllexport spir_kernel void @foo() #1 !intel_reqd_sub_group_size !2 {
+; CHECK: call spir_func void @bar(i32* undef)
+  call spir_func void @bar(<1 x i32>* undef)
+  ret void
+}
+
+attributes #0 = { noinline nounwind }
+attributes #1 = { noinline nounwind "CMGenxMain" "oclrt"="1" }
+
+!genx.kernels = !{!0}
+
+!0 = !{void ()* @foo, !"foo", !1, i32 0, i32 0, !1, !1, i32 0}
+!1 = !{}
+!2 = !{i32 1}

--- a/GenXIntrinsics/test/Adaptors/sev_signature_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/sev_signature_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13, llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test simple signatures tranform
 
 ; RUN: opt -S -GenXSPIRVReaderAdaptor < %s | FileCheck %s

--- a/GenXIntrinsics/test/Adaptors/spirv_friendly_types_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/spirv_friendly_types_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test reader translation of SPIRV friendly IR types
 
 ; RUN: opt -S -GenXSPIRVReaderAdaptor < %s | FileCheck %s

--- a/GenXIntrinsics/test/Adaptors/surface_access_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/surface_access_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test kernel surface argument translation from new style with opaque
 ; types that SPIRV translator can understand to old style with
 ; metadata. This test checks access qualifiers translation.

--- a/GenXIntrinsics/test/Adaptors/unknown_arg_reader.ll
+++ b/GenXIntrinsics/test/Adaptors/unknown_arg_reader.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; Test reader translation of implicit argument with argument kind
 ; decoration.
 

--- a/GenXIntrinsics/test/SimdCFLowering/bitcast_between_wrrs.ll
+++ b/GenXIntrinsics/test/SimdCFLowering/bitcast_between_wrrs.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; RUN: opt -S -cmsimdcflowering < %s | FileCheck %s
 
 @Rcp_T2 = internal global <64 x double> undef

--- a/GenXIntrinsics/test/SimdCFLowering/predicate_masked_gather.ll
+++ b/GenXIntrinsics/test/SimdCFLowering/predicate_masked_gather.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; RUN: opt -S -cmsimdcflowering < %s | FileCheck %s
 
 ; CHECK: @EM = internal global <32 x i1> 

--- a/GenXIntrinsics/test/SimdCFLowering/replicate_mask.ll
+++ b/GenXIntrinsics/test/SimdCFLowering/replicate_mask.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; RUN: opt -S -cmsimdcflowering < %s | FileCheck %s
 
 @g1 = internal global <64 x i32> undef

--- a/GenXIntrinsics/test/SimdCFLowering/replicate_mask_masked_gather4.ll
+++ b/GenXIntrinsics/test/SimdCFLowering/replicate_mask_masked_gather4.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; RUN: opt -S -cmsimdcflowering < %s | FileCheck %s
 
 @Rcp_T2 = internal global <64 x i32> undef

--- a/GenXIntrinsics/test/SimdCFLowering/update_mask_masked_gather4.ll
+++ b/GenXIntrinsics/test/SimdCFLowering/update_mask_masked_gather4.ll
@@ -6,7 +6,7 @@
 ;
 ;============================ end_copyright_notice =============================
 
-; XFAIL: llvm13,llvm14
+; XFAIL: llvm13, llvm14, llvm15
 ; RUN: opt -S -cmsimdcflowering < %s | FileCheck %s
 
 @g1 = internal global <64 x i32> undef


### PR DESCRIPTION
Squashed commit of the following:

commit 4ce354da51f219bbdfa9c4cd5d8f640e92e38511
Author: Victor Mustya <victor.mustya@intel.com>
Date:   Wed May 11 23:12:22 2022 +0000

    Fix for build as part of igc

    IGC build used to fail because of warnings/errors emitted by gcc

commit 1fad747bd864f302407935f692fc92a4c5755ee5
Author: Victor Mustya <victor.mustya@intel.com>
Date:   Tue May 10 21:09:28 2022 +0000

    Fix LSC helpers

    Correctly handle LSC 2d stateless intrinsics

commit 561f4ff575a198b36a72fcb790e1997d7d6d6c91
Author: Victor Mustya <victor.mustya@intel.com>
Date:   Tue May 3 17:56:40 2022 +0000

    Remove default switch labels for LSC-related functions

    Build might fail because of `-Werror -Wcovered-switch-default` options
    passed to gcc and clang

commit 1e2562d87528e1870ea2ad7197e4cc0346192e22
Author: Victor Mustya <victor.mustya@intel.com>
Date:   Mon Apr 25 20:34:16 2022 +0000

    Restore intrinsics order

    External intrinsics order is expected to be unchanged to keep SPIR-V
    compatibility.

commit 7bcfff9051cabd44cf0691d4f3b7a3ef0cd9789e
Author: Kaiyu Chen <kai.yu.chen@intel.com>
Date:   Fri Apr 22 11:33:29 2022 -0700

    [ESIMD] Add slm_init intrinsic for variable slm size support.

commit c97396d044a8b3eacf0fbad5395a4b7bbce583a8
Author: Ilya Andreev <ilya.andreev@intel.com>
Date:   Wed Mar 30 17:19:41 2022 +0300

    Extend GenXIntrinsics interface

    Add some functions to get LSC special argument indices.
    Add function to get encoded LSCVectorSize.

commit 99ac111c2604a47d865bd4d7996be8cfaf2af146
Author: Anatoly Parshintsev <anatoly.parshintsev@intel.com>
Date:   Wed Mar 16 09:37:03 2022 +0000

    add PVCXT_A0 platfrom

    add PVCXT_A0 platform and refactor the list initialization to
    simplify maintenance

commit 8db834532b07d306c54e61c6b77ac74a4a792f4d
Author: Igor Gorban <igor.gorban@intel.com>
Date:   Fri Feb 25 21:30:45 2022 +0000

    Fill debug values in created instructions

    Fill debug values in created instructions

commit 3b94702a3e5f627bed3593009a47237ebee50ca5
Author: Anton Sidorenko <anton.sidorenko@intel.com>
Date:   Mon Feb 21 14:00:20 2022 +0000

     Correct/improve lsc messages documentation

     * add one missing caching behavior (.ca)
     * separate caching documentation for loads and stores

commit e9fa035ea255ee24e3b3ca0dcd00107dc0592378
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Mon Feb 21 14:57:58 2022 +0000

     Add interface includes for in-tree mode

    Unify handling of intrinsics interface includes in both modes.

commit 328694af367a35c2ef62b2e10b98e68f4af3897d
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Mon Feb 21 08:00:12 2022 +0000

     Remove duplication of source list

    This was a source of build errors at least once.

commit a7270625195501019507017aab17e50f5dac6466
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Mon Feb 14 13:00:26 2022 +0000

     Rename exported package

    Use VCIntrinsics<LLVMVersion> naming scheme for exported package to
    solve two issues:

    1. Exported package does not have LLVM prefix to express that this is
    not LLVM project code.
    2. Exported package has explicit LLVM version in name so potential
    errors with LLVM versions mismatch can be caught earlier.

    Old LLVMGenXIntrinsics export is left for backward compatibility. It
    will be removed later.

commit e45940b947892e724e6c4fb954c5464f9ae4aa66
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Mon Feb 14 14:58:22 2022 +0000

     Use getPointerElementType for pointee types

    PointerType::getElementType() was removed from LLVM.

    https://reviews.llvm.org/rGd593cf79458a59d37e75c886a4fc3ac6a02b484d

commit 8b6e209fe1269a2c6470b36dfbaa0e051d2a100f
Author: Konstantin Vladimirov <konstantin.vladimirov@intel.com>
Date:   Tue Feb 8 10:47:03 2022 +0000

    introducing named barrier support in adaptor pass

    named barrier required for DPC++ and other customers

commit 9b2ae13a645538565c8a32993ca1791797221e55
Author: Nikita Rudenko <nikita.rudenko@intel.com>
Date:   Fri Feb 4 17:04:42 2022 +0000

     Remove XFAIL from some tests

    Remove XFAIL from some tests

commit 91071ac9d072adebbe59bbbd6ad502ab5c781048
Author: Yuly Tarasov <yuly.tarasov@intel.com>
Date:   Tue Feb 8 13:22:43 2022 +0300

    Add add3c intrinsic

    Add add3 with carry intrinsic

commit 5066d947985dd0c5107765daec5f24f735f3259a
Author: y <viacheslav.chernonog@intel.com>
Date:   Mon Feb 7 23:12:24 2022 +0300

    add ADLP and ADLS platforms

commit a9bb6d8040c43404c5fbe3694e59c503d179d19a
Author: Nikita Rudenko <nikita.rudenko@intel.com>
Date:   Tue Feb 1 14:57:43 2022 +0000

     Fix attributes are not forwarded for call inst with SEV

    GenXSingleElementVectorUtil did not forward metadata and attributes
    for call instructions with SEV. This commit fixes it.

commit a3ca3a364a92ed966a337d9154f9f2d02b0efc5a
Author: Nikita Rudenko <nikita.rudenko@intel.com>
Date:   Thu Feb 3 14:10:33 2022 +0000

     Set some tests to XFAIL on latest LLVM 15

    Set some tests to XFAIL on latest LLVM 15

commit a7a3efa116ae165132508f3f9a975fccb196fede
Author: Anatoly Parshintsev <anatoly.parshintsev@intel.com>
Date:   Wed Jan 26 15:11:43 2022 +0000

     Fix potential null pointer dereference

    dyn_extract implies that nullptr can be returned, while in this case
    we need a more strict check.

commit d2f78f24314cd5aad1f633042cf5ae49b0ecdb24
Author: Sergey Semenov <sergey.semenov@intel.com>
Date:   Tue Jan 25 17:59:19 2022 +0000

     Fix an issue with GenXIntrinsicDescription.gen includes

    Fix an issue where GenXIntrinsicDescription.gen is included without
    including map header.

commit 3a5f4b4608f0e18fcdc04d851568f3aab4651545
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Tue Jan 11 12:23:57 2022 +0000

     Fix buildfail on ToT caused by D116110

    Remove unused wrapper to fix buildfail because of attribute removal
    API change. New class was added in D116110 and wrapping of this case
    is not trivial so removal of unneeded function is the easiest
    solution.

commit 753ad5002af5a5e467b3a0194a2b0e9a3243059e
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Thu Oct 7 10:41:10 2021 +0000

     Remove legacy simd8 intrinsics

    VC always uses simd1 mode with separate intrinsics.

commit 09ff7f80a6db1831de1ea5494a425184d490df1e
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Tue Oct 26 14:13:13 2021 +0000

     Remove wrappers for LLVM 7

    VC intrinsics no longer support LLVM 7.

commit 84308bec33fb1c15dd03c82f5c97145f3756add9
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Fri Oct 29 17:57:35 2021 +0000

     Provide cmake error when unsupported LLVM found

    Fail earlier on configuration stage.

commit d3cef33488b7d7a23dffe49aac42c2759b447dcf
Author: Dmitry Ryabtsev <dmitry.ryabtsev1@intel.com>
Date:   Thu Dec 9 15:49:28 2021 +0000

    Fix lack of includes in GenXMetadata.h

    GetOldStyleKernelMD implementation was moved out of the header.
    Proper forward declarations were added.

commit 381535d6c25c794adf164fae0d0cfdd6a18a09a5
Author: Anton Sidorenko <anton.sidorenko@intel.com>
Date:   Thu Dec 2 11:22:37 2021 +0000

    Stack calls are not necessary to be noinline

    If the stack call must not be inlined, NoInline attribute should be
    added by the FE, but not by the SPIRV reader adapter.

commit 8ee879314584e6630688b0a3b290d065dcabb383
Author: Konstantin Vladimirov <konstantin.vladimirov@intel.com>
Date:   Tue Nov 2 10:08:40 2021 +0000

    Introducing VC intrinsics interface for DG2 and PVC platforms

    A number of new intrinsics introduced

commit 4f460713c90662e20a56840d48466aeb18c9ef81
Author: DmitryBushev <dmitry.bushev@intel.com>
Date:   Tue Oct 12 15:08:20 2021 +0000

    Fixed SPIRVWriterAdaptor pass not adding attribute on address convert intrinsic

    SPIRVWriterAdaptor pass may add llvm.genx.address_convert intrinsics. Doing so
    it must explicitly add VCFunction attribute to newly created intrinsics.

commit c6e0c45edd7d8234ea271b0cbf11126dd5f3404b
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Wed Oct 27 21:36:00 2021 +0000

    Normalize ifs in cmake code

    Normalize ifs in cmake code

commit ed60a79bc552c1fb81b1e9251ba0d235237635cd
Author: Stanislav Sidelnikov <stanislav.sidelnikov@intel.com>
Date:   Mon Oct 25 11:19:30 2021 +0000

    Updating source files permissions

    Removed executuion bit in sources

commit d6d08b3b02af08ed4cd78029f5eee806ede657c7
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Tue Oct 19 13:00:16 2021 +0000

    Bump minimum supported LLVM version to 8

commit 6a7e93d3d90638b6565d97cef96ffaf0f77d688c
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Mon Oct 18 18:03:24 2021 +0000

    Wrap arg_size for call instructions

    Build fix after:
    https://reviews.llvm.org/rGb2ee408dde374d6a27a34746fd7c7b5bab97ea89

commit 2cd5a7b013d09d21ad206708943faf0b575e0ece
Author: Anatoly Parshintsev <anatoly.parshintsev@intel.com>
Date:   Thu Oct 7 12:25:27 2021 +0000

    introduce new RKL platform

commit 2140c91a241703d7d6c39d1b86e7684b2558d9d5
Author: Anatoly Parshintsev <anatoly.parshintsev@intel.com>
Date:   Fri Oct 1 14:36:09 2021 +0000

    spirv reader adaptor should discard redundant attributes

commit 9aafb518a05be160beffd7812a0f169c10786d04
Author: DmitryBushev <dmitry.bushev@intel.com>
Date:   Tue Sep 28 16:24:03 2021 +0000

    SPIRV-LLVM-Translator may convert native SPIRV types to 'SPIRV friendly IR' types
    defined in translator docs if dedicated option is passed. Adaptor should be able
    to read them as well as OCL types.

commit 465abdd6522b8e21b2c60ca2694bc8964a24c164
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Thu Sep 23 17:52:34 2021 +0000

    Add media block images to SPIRV adaptors

    Translate arguments annotated with "image2d_media_block_t" to special
    opaque type. New annotation is required to distinguish media block
    images and texture images.

commit 5c8159af873c96110c1b354f8660c044ff6b35b0
Author: Anatoly Parshintsev <anatoly.parshintsev@intel.com>
Date:   Sun Sep 26 06:19:09 2021 +0000

    Cleanup unnecessary/deprecated attributes from test

commit 085fcacac61e4012db8c7a175c43d7aa23f1911a
Author: DmitryBushev <dmitry.bushev@intel.com>
Date:   Tue Sep 7 17:07:27 2021 +0000

    In case there no kernels in module, SPIRV adaptor passes would skip proccessing
    of all functions that is not right

commit 5647df399355098aa5e8fe2c5c6bab2442533224
Author: Kirill Yansitov <kirill.yansitov@intel.com>
Date:   Mon Sep 13 12:29:38 2021 +0000

    Add 3rd argument for imad

commit 7a46e7e3ea7eef37cc1a77043fd1bf6a3cab1d9e
Author: Parshintsev Anatoly <anatoly.parshintsev@intel.com>
Date:   Fri Sep 10 23:54:05 2021 +0300

    More robust procedure to query availability of an intrinsic on a particular platform

commit 4e2a1cebbf5c47563d92785d04d8e0c614857a93
Author: Anatoly Parshintsev <anatoly.parshintsev@intel.com>
Date:   Wed Sep 8 23:02:41 2021 +0000

    synchornize platform list

commit e5ad7e02aa4aa21a3cd7b3e5d1f3ec9b95f58872
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Tue Sep 7 12:30:52 2021 +0000

    Add image array conversion in spirv adaptors

commit b1db3e55bac23670be4ffbd0da85a9fd0110f593
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Fri Sep 3 10:36:49 2021 +0000

    Wrap attribute at index methods

    Fix after https://reviews.llvm.org/D108614.

commit b66c5bbd66dc4a556fc624122d835552b3516f14
Author: Kirill Yansitov <kirill.yansitov@intel.com>
Date:   Tue Aug 31 16:22:22 2021 +0000

    Add intrinsics to represent cm_imul builtin
    This intrinsic doesn't produce vISA instr and must be lower in backend
    Small fixes in madw description to allow only width equal 2GRF/sizeof(i32)

commit 006d176f31b4ebf5e2c2ad8befb8d0227112bb0a
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Fri Aug 20 13:12:43 2021 +0000

    Remove odd specifiers from functions in headers

    Remove static from inline functions in headers. Remove inline from
    in-class static function definitions. Replace static with inline for
    functions in wrapper headers.

commit a2f2f10dc61c8161c57cf33ed606c8e3ccf3a921
Author: DenisBakhvalov <61807338+DenisBakhvalov@users.noreply.github.com>
Date:   Thu Aug 19 15:58:05 2021 -0700

    Fix Cmake Error

    When building DPCPP compiler I saw the following error:

    CMake Error at /llvm/cmake/modules/LLVMProcessSources.cmake:114 (message):
      Found unknown source file AdaptorsCommon.cpp

commit 6221091b0a6b97c9bd9147d03ad09fbe74b8d89f
Author: Dmitry Bushev <dmitry.bushev@intel.com>
Date:   Thu Aug 19 16:42:01 2021 +0300

    Fix llvm verifier assertion

    SPIRVAdaptor passes didn't properly handle the pointer attributes when rewiting
    types in kernel signature leading to module verification failure

commit 2bbb573f4030c3006031a585b2ab2b027fe0a507
Author: Bargatin-Intel <mikhail.bargatin@intel.com>
Date:   Wed Aug 18 13:42:58 2021 +0300

    Add missing header

commit fd9bf4b3a91f853ed74a376df58123bb75f64449
Author: Aleksander Us <aleksander.us@intel.com>
Date:   Mon Aug 16 13:28:05 2021 +0000

    Wrap AttributeList::hasFnAttr

    Fix intrinsics build after
    https://reviews.llvm.org/rG92ce6db9ee7666a347fccf0f72ba3225b199d6d1

commit 90113a56d0f0b67b268d55e685dc3c00dad9e3a0
Author: Kirill Yansitov <kirill.yansitov@intel.com>
Date:   Fri Jul 30 21:26:25 2021 +0000

    add intrinsic to represent visa madw instr

commit 4e3870da11247096c1d2524e858bd2ae3df5175d
Author: Dmitriy Drozdov <dmitriy.drozdov@intel.com>
Date:   Thu Jul 29 09:47:33 2021 +0000

    Revert "Introduce new vc intrinsic to access timestamp register"

commit 0bf761ef358d70b5a27292845f0def764aeb8a7f
Author: Dmitriy Drozdov <dmitriy.drozdov@intel.com>
Date:   Thu Jul 29 16:29:49 2021 +0000

    Mark lit tests as XFAIL for llvm 14 (tot)

commit 05d3f3d2b9ae59d32893976e0e76415fec1108b9
Author: Nikita Rudenko <nikita.rudenko@intel.com>
Date:   Thu Jun 24 14:54:03 2021 +0000

    Add global variables support to GenXSingleElementVector pass

commit 43b1af8933c75c045c7d5e659bf98eaa57811071
Author: Nikita Rudenko <nikita.rudenko@intel.com>
Date:   Tue Jul 27 12:36:20 2021 +0000

    Fix typo in GenXIntrinsics/CMakeLists.txt

commit 185f382cc9d564d34c3cb9452762e496f43d3fd7
Author: lgotszal <lukasz.gotszald@intel.com>
Date:   Thu Jul 22 07:43:26 2021 +0000

    update copyright headers
    update Python copyright to PEP8 style

commit 63cbfe0b0d68fa0c2d66b8a4a676c2bb3f01facf
Author: lgotszal <lukasz.gotszald@intel.com>
Date:   Tue Jul 6 10:55:54 2021 +0000

    update MIT copyright headers

commit f45e04c6aa293d04da97f902aa9aa766a525e017
Author: Dmitriy Drozdov <dmitriy.drozdov@intel.com>
Date:   Tue Jul 20 15:15:02 2021 +0000

    Introduce new vc intrinsic to access timestamp register