### PR TITLE
Format InstructionSimplify names

### DIFF
--- a/GenXIntrinsics/include/llvmVCWrapper/Analysis/InstructionSimplify.h
+++ b/GenXIntrinsics/include/llvmVCWrapper/Analysis/InstructionSimplify.h
@@ -1,0 +1,58 @@
+/*========================== begin_copyright_notice ============================
+
+INTEL CONFIDENTIAL
+
+Copyright (C) 2022 Intel Corporation
+
+This software and the related documents are Intel copyrighted materials,
+and your use of them is governed by the express license under which they were
+provided to you ("License"). Unless the License provides otherwise,
+you may not use, modify, copy, publish, distribute, disclose or transmit this
+software or the related documents without Intel's prior written permission.
+
+This software and the related documents are provided as is, with no express or
+implied warranties, other than those that are expressly stated in the License.
+
+============================= end_copyright_notice ===========================*/
+
+#ifndef VCINTR_ANALYSIS_INSTRUCTIONSIMPLIFY_H
+#define VCINTR_ANALYSIS_INSTRUCTIONSIMPLIFY_H
+
+#include <llvm/Analysis/InstructionSimplify.h>
+
+namespace VCINTR {
+
+inline llvm::Value *SimplifyInsertElementInst(llvm::Value *Vec,
+                                              llvm::Value *Elt,
+                                              llvm::Value *Idx,
+                                              const llvm::SimplifyQuery &Q) {
+#if VC_INTR_LLVM_VERSION_MAJOR <= 14
+  return llvm::SimplifyInsertElementInst(Vec, Elt, Idx, Q);
+#else
+  return llvm::simplifyInsertElementInst(Vec, Elt, Idx, Q);
+#endif
+}
+
+inline llvm::Value *SimplifyExtractElementInst(llvm::Value *Vec,
+                                               llvm::Value *Idx,
+                                               const llvm::SimplifyQuery &Q) {
+#if VC_INTR_LLVM_VERSION_MAJOR <= 14
+  return llvm::SimplifyExtractElementInst(Vec, Idx, Q);
+#else
+  return llvm::simplifyExtractElementInst(Vec, Idx, Q);
+#endif
+}
+
+inline llvm::Value *SimplifyCastInst(unsigned CastOpc, llvm::Value *Op,
+                                     llvm::Type *Ty,
+                                     const llvm::SimplifyQuery &Q) {
+#if VC_INTR_LLVM_VERSION_MAJOR <= 14
+  return llvm::SimplifyCastInst(CastOpc, Op, Ty, Q);
+#else
+  return llvm::simplifyCastInst(CastOpc, Op, Ty, Q);
+#endif
+}
+
+} // namespace VCINTR
+
+#endif // VCINTR_ANALYSIS_INSTRUCTIONSIMPLIFY_H

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXSingleElementVectorUtil.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXSingleElementVectorUtil.cpp
@@ -22,6 +22,7 @@ SPDX-License-Identifier: MIT
 #include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
 
+#include "llvmVCWrapper/Analysis/InstructionSimplify.h"
 #include "llvmVCWrapper/IR/Attributes.h"
 #include "llvmVCWrapper/IR/DerivedTypes.h"
 #include "llvmVCWrapper/IR/Function.h"
@@ -852,7 +853,7 @@ static void collapseBitcastInst(BitCastInst *BitCast, bool CollapseCannotFail) {
   }
   auto &&M = *BitCast->getModule();
   auto &&Q = SimplifyQuery(M.getDataLayout());
-  auto *ReplaceWith = SimplifyCastInst(
+  auto *ReplaceWith = VCINTR::SimplifyCastInst(
       BitCast->getOpcode(), BitCast->getOperand(0), BitCast->getType(), Q);
   if (!CollapseCannotFail && !ReplaceWith)
     return;
@@ -893,8 +894,8 @@ static void collapseExtractInst(ExtractElementInst *Extract,
   }
   auto &&M = *Extract->getModule();
   auto &&Q = SimplifyQuery(M.getDataLayout());
-  auto *ReplaceWith = SimplifyExtractElementInst(Extract->getOperand(0),
-                                                 Extract->getOperand(1), Q);
+  auto *ReplaceWith = VCINTR::SimplifyExtractElementInst(
+      Extract->getOperand(0), Extract->getOperand(1), Q);
   if (!CollapseCannotFail && !ReplaceWith)
     return;
   assert(ReplaceWith && "Oops... Cannot collapse ExtractElement instruction");
@@ -910,7 +911,7 @@ static void collapseInsertInst(InsertElementInst *Insert,
   }
   auto &&M = *Insert->getModule();
   auto &&Q = SimplifyQuery(M.getDataLayout());
-  auto *ReplaceWith = SimplifyInsertElementInst(
+  auto *ReplaceWith = VCINTR::SimplifyInsertElementInst(
       Insert->getOperand(0), Insert->getOperand(1), Insert->getOperand(2), Q);
 
   // SimplifyInsertElementInst provides too simple analysis


### PR DESCRIPTION
Format method names to be consistent with InstructionSimplify header.
