### PR TITLE
Make intrinsics module searching more robust

### DIFF
--- a/GenXIntrinsics/include/llvm/GenXIntrinsics/Intrinsics.py
+++ b/GenXIntrinsics/include/llvm/GenXIntrinsics/Intrinsics.py
@@ -117,6 +117,7 @@ for i in range(len(parse)):
     #Populate the dictionary with the appropriate Intrinsics
     if i != 0:
         if (".py" in parse[i]):
+            sys.path.append(os.path.split(parse[i])[0])
             module = importlib.import_module(os.path.split(parse[i])[1].replace(".py",""))
             Intrinsics.update(module.Imported_Intrinsics)
 


### PR DESCRIPTION
Portable(or embedded) versions of python don't have the script
directory in the module search path by default. So, adding the
expected module directory in the script itself allows the script
work correctly even with such versions of python.