### PR TITLE
Fix build after llvm commit 4b6b248731b81deb471838ff79392993aeb6c621

### DIFF
--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVReaderAdaptor.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVReaderAdaptor.cpp
@@ -267,10 +267,10 @@ static Optional<SPIRVArgDesc> parseSPIRVIRType(StringRef TyName) {
 // Assume that "opencl." "spirv." and "intel.buffer" types are well-formed.
 static Optional<SPIRVArgDesc> parseOpaqueType(StringRef TyName) {
   if (auto MaybeIntelTy = parseIntelType(TyName))
-    return MaybeIntelTy.getValue();
+    return MaybeIntelTy.value();
 
   if (auto MaybeOCL = parseOCLType(TyName))
-    return MaybeOCL.getValue();
+    return MaybeOCL.value();
 
   return parseSPIRVIRType(TyName);
 }
@@ -306,7 +306,7 @@ static SPIRVArgDesc analyzeKernelArg(const Argument &Arg) {
     return {SPIRVType::Pointer};
 
   if (auto MaybeDesc = parseOpaqueType(StrTy->getName())) {
-    SPIRVArgDesc Desc = MaybeDesc.getValue();
+    SPIRVArgDesc Desc = MaybeDesc.value();
     assert(getOpaqueTypeAddressSpace(Desc.Ty) == AddressSpace &&
            "Mismatching address space for type");
     return Desc;

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp
@@ -54,7 +54,7 @@ private:
   void overrideOptionsWithEnv() {
     auto RewriteSEVOpt = llvm::sys::Process::GetEnv("GENX_REWRITE_SEV");
     if (RewriteSEVOpt)
-      RewriteSingleElementVectors = RewriteSEVOpt.getValue() == "1";
+      RewriteSingleElementVectors = RewriteSEVOpt.value() == "1";
   }
 
   bool runOnFunction(Function &F);
@@ -285,7 +285,7 @@ static SPIRVArgDesc parseArgDesc(StringRef Desc) {
   if (!AccTy)
     AccTy = AccessType::ReadWrite;
 
-  return {Ty.getValue(), AccTy.getValue()};
+  return {Ty.value(), AccTy.value()};
 }
 
 // General arguments can be either pointers or any other types.
@@ -386,7 +386,7 @@ static StringRef extractArgumentDesc(const Argument &Arg) {
 static SPIRVArgDesc analyzeKernelArg(const Argument &Arg) {
   if (auto Kind = extractArgumentKind(Arg)) {
     const StringRef Desc = extractArgumentDesc(Arg);
-    return analyzeArgumentAttributes(Kind.getValue(), Desc);
+    return analyzeArgumentAttributes(Kind.value(), Desc);
   }
 
   return {SPIRVType::None};


### PR DESCRIPTION
Optional::{has_value,value}, etc are removed.