### PR TITLE
Get rid of llvm::Optional usages

### DIFF
--- a/GenXIntrinsics/include/llvm/GenXIntrinsics/GenXIntrinsics.h
+++ b/GenXIntrinsics/include/llvm/GenXIntrinsics/GenXIntrinsics.h
@@ -17,7 +17,6 @@ SPDX-License-Identifier: MIT
 #ifndef GENX_INTRINSIC_INTERFACE_H
 #define GENX_INTRINSIC_INTERFACE_H
 
-#include "llvm/ADT/None.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/Function.h"

--- a/GenXIntrinsics/include/llvmVCWrapper/IR/Instructions.h
+++ b/GenXIntrinsics/include/llvmVCWrapper/IR/Instructions.h
@@ -10,7 +10,6 @@ SPDX-License-Identifier: MIT
 #define VCINTR_IR_INSTRUCTIONS_H
 
 #include <algorithm>
-#include <llvm/ADT/Optional.h>
 #include <llvm/IR/Instructions.h>
 
 namespace VCINTR {
@@ -44,7 +43,7 @@ inline llvm::ArrayRef<int> getShuffleMask(llvm::ArrayRef<int> Mask,
 } // namespace ShuffleVectorInst
 
 template <class ArgKind>
-inline ArgKind &getValue(llvm::Optional<ArgKind> &opt) {
+inline ArgKind &getValue(std::optional<ArgKind> &opt) {
 #if VC_INTR_LLVM_VERSION_MAJOR < 15
   return opt.getValue();
 #else
@@ -53,7 +52,7 @@ inline ArgKind &getValue(llvm::Optional<ArgKind> &opt) {
 }
 
 template <class ArgKind>
-inline const ArgKind &getValue(const llvm::Optional<ArgKind> &opt) {
+inline const ArgKind &getValue(const std::optional<ArgKind> &opt) {
 #if VC_INTR_LLVM_VERSION_MAJOR < 15
   return opt.getValue();
 #else

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVReaderAdaptor.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVReaderAdaptor.cpp
@@ -201,7 +201,7 @@ static SPIRVArgDesc parseSPIRVIRImageType(StringRef TyName) {
   return {ResultType, AccessTy};
 }
 
-static Optional<SPIRVArgDesc> parseIntelType(StringRef TyName) {
+static std::optional<SPIRVArgDesc> parseIntelType(StringRef TyName) {
   if (!TyName.consume_front(IntelTypes::TypePrefix))
     return {};
 
@@ -213,7 +213,7 @@ static Optional<SPIRVArgDesc> parseIntelType(StringRef TyName) {
   return SPIRVArgDesc{MainType, AccType};
 }
 
-static Optional<SPIRVArgDesc> parseOCLType(StringRef TyName) {
+static std::optional<SPIRVArgDesc> parseOCLType(StringRef TyName) {
   if (!TyName.consume_front(OCLTypes::TypePrefix))
     return {};
 
@@ -227,7 +227,7 @@ static Optional<SPIRVArgDesc> parseOCLType(StringRef TyName) {
   return parseImageType(TyName);
 }
 
-static Optional<SPIRVArgDesc> parseSPIRVIRType(StringRef TyName) {
+static std::optional<SPIRVArgDesc> parseSPIRVIRType(StringRef TyName) {
   if (!TyName.consume_front(SPIRVIRTypes::TypePrefix))
     return {};
 
@@ -248,7 +248,7 @@ static Optional<SPIRVArgDesc> parseSPIRVIRType(StringRef TyName) {
 // SPVImageTy -> "Image." _..._{Dim}_..._{Arrayed}_..._{Acc}
 // Dim, Arrayed, Acc - literal operands matching OpTypeImage operands in SPIRV
 // Assume that "opencl." "spirv." and "intel.buffer" types are well-formed.
-static Optional<SPIRVArgDesc> parseOpaqueType(StringRef TyName) {
+static std::optional<SPIRVArgDesc> parseOpaqueType(StringRef TyName) {
   if (auto MaybeIntelTy = parseIntelType(TyName))
     return VCINTR::getValue(MaybeIntelTy);
 

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp
@@ -356,11 +356,11 @@ static SPIRVArgDesc parseArgDesc(StringRef Desc) {
   Desc.split(Tokens, /*Separator=*/' ', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
 
   // Scan tokens until end or required info is found.
-  Optional<AccessType> AccTy;
-  Optional<SPIRVType> Ty;
+  std::optional<AccessType> AccTy;
+  std::optional<SPIRVType> Ty;
   for (StringRef Tok : Tokens) {
     if (!Ty) {
-      Ty = StringSwitch<Optional<SPIRVType>>(Tok)
+      Ty = StringSwitch<std::optional<SPIRVType>>(Tok)
                .Case(ArgDesc::Buffer, SPIRVType::Buffer)
                .Case(ArgDesc::Image1d, SPIRVType::Image1d)
                .Case(ArgDesc::Image1dArray, SPIRVType::Image1dArray)
@@ -375,7 +375,7 @@ static SPIRVArgDesc parseArgDesc(StringRef Desc) {
     }
 
     if (!AccTy) {
-      AccTy = StringSwitch<Optional<AccessType>>(Tok)
+      AccTy = StringSwitch<std::optional<AccessType>>(Tok)
                   .Case(ArgDesc::ReadOnly, AccessType::ReadOnly)
                   .Case(ArgDesc::WriteOnly, AccessType::WriteOnly)
                   .Case(ArgDesc::ReadWrite, AccessType::ReadWrite)
@@ -466,7 +466,7 @@ static SPIRVArgDesc analyzeArgumentAttributes(ArgKind Kind, StringRef Desc) {
 // value can be out of listed in ArgKind enum.
 // Such values are not processed later.
 // Return None if there is no such attribute.
-static Optional<ArgKind> extractArgumentKind(const Argument &Arg) {
+static std::optional<ArgKind> extractArgumentKind(const Argument &Arg) {
   const Function *F = Arg.getParent();
   const AttributeList Attrs = F->getAttributes();
   if (!Attrs.hasParamAttr(Arg.getArgNo(), VCFunctionMD::VCArgumentKind))


### PR DESCRIPTION
llvm::Optional is removed from LLVM:
 commit 397f2e9ebee8d8e45547e90dd05228d7f965df67
 Author: Kazu Hirata <kazu@google.com>
 Date:   Tue May 30 15:32:43 2023 -0700

     Remove llvm::Optional

     This is part of an effort to migrate from llvm::Optional to std::optional:

     https://discourse.llvm.org/t/deprecating-llvm-optional-x-hasvalue-getvalue-getvalueor/63716

     Differential Revision: https://reviews.llvm.org/D149128