### PR TITLE
Replace all uses before removing function

### DIFF
--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp
@@ -541,7 +541,8 @@ static void rewriteKernelArguments(Function &F) {
   Instruction *InsPt = &NewF->getEntryBlock().front();
   for (auto &&ArgPair : llvm::zip(F.args(), NewF->args()))
     rewriteArgumentUses(InsPt, std::get<0>(ArgPair), std::get<1>(ArgPair));
-
+  
+  F.replaceAllUsesWith(NewF);
   F.eraseFromParent();
 }
 


### PR DESCRIPTION
There might be module level named metadata referencing old function, so we have to replace all uses before removing old function.