### PR TITLE
Fixed upstream pulldown build error

### DIFF
--- a/GenXIntrinsics/lib/GenXIntrinsics/AdaptorsCommon.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/AdaptorsCommon.cpp
@@ -40,7 +40,9 @@ void legalizeParamAttributes(Function *F) {
       continue;
 
 #if VC_INTR_LLVM_VERSION_MAJOR >= 13
+#if VC_INTR_LLVM_VERSION_MAJOR < 18
     if (PTy->isOpaque())
+#endif // VC_INTR_LLVM_VERSION_MAJOR < 18
       continue;
 #endif // VC_INTR_LLVM_VERSION_MAJOR >= 13
 

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp
@@ -431,7 +431,9 @@ static std::string getMangledTypeStr(Type *Ty) {
   if (PointerType *PTyp = dyn_cast<PointerType>(Ty)) {
     Result += "p" + llvm::utostr(PTyp->getAddressSpace());
 #if VC_INTR_LLVM_VERSION_MAJOR >= 13
+#if VC_INTR_LLVM_VERSION_MAJOR < 18
     if (PTyp->isOpaque())
+#endif // VC_INTR_LLVM_VERSION_MAJOR < 18
       return Result;
 #endif // VC_INTR_LLVM_VERSION_MAJOR >= 13
     Result += getMangledTypeStr(VCINTR::Type::getNonOpaquePtrEltTy(PTyp));


### PR DESCRIPTION
llvm community removed deprecated api  which always return ture https://github.com/llvm/llvm-project/commit/651a49c4b6bdef81c8deddbe653258c066867a58.