### PR TITLE
Suppress various deprecation warnings on LLVM 17+

### DIFF
--- a/GenXIntrinsics/include/llvm/GenXIntrinsics/GenXIntrinsicInst.h
+++ b/GenXIntrinsics/include/llvm/GenXIntrinsics/GenXIntrinsicInst.h
@@ -33,6 +33,8 @@ SPDX-License-Identifier: MIT
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 
+#include "llvmVCWrapper/ADT/StringRef.h"
+
 namespace llvm {
 /// IntrinsicInst - A useful wrapper class for inspecting calls to intrinsic
 /// functions.  This allows the standard isa/dyncast/cast functionality to
@@ -52,7 +54,8 @@ public:
   // Methods for support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const CallInst *I) {
     if (const Function *CF = I->getCalledFunction()) {
-      return CF->getName().startswith(GenXIntrinsic::getGenXIntrinsicPrefix());
+      return VCINTR::StringRef::starts_with(
+          CF->getName(), GenXIntrinsic::getGenXIntrinsicPrefix());
     }
     return false;
   }

--- a/GenXIntrinsics/include/llvm/GenXIntrinsics/GenXIntrinsics.h
+++ b/GenXIntrinsics/include/llvm/GenXIntrinsics/GenXIntrinsics.h
@@ -24,6 +24,8 @@ SPDX-License-Identifier: MIT
 #include "llvm/IR/Instructions.h"
 #include "llvm/GenXIntrinsics/GenXVersion.h"
 
+#include "llvmVCWrapper/ADT/StringRef.h"
+
 namespace llvm {
 
 namespace GenXIntrinsic {
@@ -139,7 +141,8 @@ inline bool isGenXIntrinsic(unsigned ID) {
 /// It's possible for this function to return true while getGenXIntrinsicID()
 /// returns GenXIntrinsic::not_genx_intrinsic!
 inline bool isGenXIntrinsic(const Function *CF) {
-  return CF->getName().startswith(getGenXIntrinsicPrefix());
+  return VCINTR::StringRef::starts_with(CF->getName(),
+                                        getGenXIntrinsicPrefix());
 }
 
 /// GenXIntrinsic::isGenXIntrinsic(V) - Returns true if

--- a/GenXIntrinsics/include/llvmVCWrapper/ADT/StringRef.h
+++ b/GenXIntrinsics/include/llvmVCWrapper/ADT/StringRef.h
@@ -1,0 +1,30 @@
+/*========================== begin_copyright_notice ============================
+
+Copyright (C) 2020-2022 Intel Corporation
+
+SPDX-License-Identifier: MIT
+
+============================= end_copyright_notice ===========================*/
+
+#ifndef VCINTR_ADT_STRINGREF_H
+#define VCINTR_ADT_STRINGREF_H
+
+#include <llvm/ADT/StringRef.h>
+
+namespace VCINTR {
+
+namespace StringRef {
+
+inline bool starts_with(llvm::StringRef S, llvm::StringRef Prefix) {
+#if VC_INTR_LLVM_VERSION_MAJOR >= 16
+  return S.starts_with(Prefix);
+#else
+  return S.startswith(Prefix);
+#endif // VC_INTR_LLVM_VERSION_MAJOR >= 16
+}
+
+} // namespace StringRef
+
+} // namespace VCINTR
+
+#endif

--- a/GenXIntrinsics/include/llvmVCWrapper/IR/Type.h
+++ b/GenXIntrinsics/include/llvmVCWrapper/IR/Type.h
@@ -17,9 +17,11 @@ namespace Type {
 inline llvm::Type *getNonOpaquePtrEltTy(const llvm::Type *PTy) {
 #if VC_INTR_LLVM_VERSION_MAJOR < 14
   return PTy->getPointerElementType();
-#else  // VC_INTR_LLVM_VERSION_MAJOR < 14
+#elif VC_INTR_LLVM_VERSION_MAJOR < 17
   return PTy->getNonOpaquePointerElementType();
-#endif // VC_INTR_LLVM_VERSION_MAJOR < 14
+#else
+  llvm_unreachable("Pointers no longer have element types");
+#endif // VC_INTR_LLVM_VERSION_MAJOR < 17
 }
 
 } // namespace Type

--- a/GenXIntrinsics/lib/GenXIntrinsics/AdaptorsCommon.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/AdaptorsCommon.cpp
@@ -40,9 +40,9 @@ void legalizeParamAttributes(Function *F) {
       continue;
 
 #if VC_INTR_LLVM_VERSION_MAJOR >= 13
-#if VC_INTR_LLVM_VERSION_MAJOR < 18
+#if VC_INTR_LLVM_VERSION_MAJOR < 17
     if (PTy->isOpaque())
-#endif // VC_INTR_LLVM_VERSION_MAJOR < 18
+#endif // VC_INTR_LLVM_VERSION_MAJOR < 17
       continue;
 #endif // VC_INTR_LLVM_VERSION_MAJOR >= 13
 

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp
@@ -31,6 +31,7 @@ See LICENSE.TXT for details.
 #include <llvm/ADT/StringMap.h>
 #include <llvm/CodeGen/ValueTypes.h>
 
+#include "llvmVCWrapper/ADT/StringRef.h"
 #include "llvmVCWrapper/IR/DerivedTypes.h"
 #include "llvmVCWrapper/IR/Intrinsics.h"
 #include "llvmVCWrapper/IR/Type.h"
@@ -536,7 +537,7 @@ bool GenXIntrinsic::isOverloadedRet(unsigned IntrinID) {
 ///
 /// Returns the relevant slice of \c IntrinsicNameTable
 static ArrayRef<const char *> findTargetSubtable(StringRef Name) {
-  assert(Name.startswith("llvm.genx."));
+  assert(VCINTR::StringRef::starts_with(Name, "llvm.genx."));
 
   ArrayRef<IntrinsicTargetInfo> Targets(TargetInfos);
   // Drop "llvm." and take the first dotted component. That will be the target
@@ -554,7 +555,7 @@ static ArrayRef<const char *> findTargetSubtable(StringRef Name) {
 GenXIntrinsic::ID GenXIntrinsic::getGenXIntrinsicID(const Function *F) {
   assert(F);
   llvm::StringRef Name = F->getName();
-  if (!Name.startswith(getGenXIntrinsicPrefix()))
+  if (!VCINTR::StringRef::starts_with(Name, getGenXIntrinsicPrefix()))
     return GenXIntrinsic::not_genx_intrinsic;
 
   // Check metadata cache.
@@ -568,7 +569,7 @@ GenXIntrinsic::ID GenXIntrinsic::getGenXIntrinsicID(const Function *F) {
     if (isGenXIntrinsic(Id)) {
       const char *NamePrefix =
           GenXIntrinsicNameTable[Id - GenXIntrinsic::not_genx_intrinsic];
-      if (Name.startswith(NamePrefix))
+      if (VCINTR::StringRef::starts_with(Name, NamePrefix))
         return Id;
     }
   }

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp
@@ -432,9 +432,9 @@ static std::string getMangledTypeStr(Type *Ty) {
   if (PointerType *PTyp = dyn_cast<PointerType>(Ty)) {
     Result += "p" + llvm::utostr(PTyp->getAddressSpace());
 #if VC_INTR_LLVM_VERSION_MAJOR >= 13
-#if VC_INTR_LLVM_VERSION_MAJOR < 18
+#if VC_INTR_LLVM_VERSION_MAJOR < 17
     if (PTyp->isOpaque())
-#endif // VC_INTR_LLVM_VERSION_MAJOR < 18
+#endif // VC_INTR_LLVM_VERSION_MAJOR < 17
       return Result;
 #endif // VC_INTR_LLVM_VERSION_MAJOR >= 13
     Result += getMangledTypeStr(VCINTR::Type::getNonOpaquePtrEltTy(PTyp));

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp
@@ -28,6 +28,7 @@ SPDX-License-Identifier: MIT
 #include "llvm/Pass.h"
 #include "llvm/Support/Process.h"
 
+#include "llvmVCWrapper/ADT/StringRef.h"
 #include "llvmVCWrapper/IR/Attributes.h"
 #include "llvmVCWrapper/IR/DerivedTypes.h"
 #include "llvmVCWrapper/IR/Function.h"
@@ -577,8 +578,8 @@ static inline void FixAttributes(Function &F, Attribute::AttrKind Attr,
 
 bool GenXSPIRVWriterAdaptorImpl::run(Module &M) {
   auto TargetTriple = StringRef(M.getTargetTriple());
-  if (TargetTriple.startswith("genx")) {
-    if (TargetTriple.startswith("genx32"))
+  if (VCINTR::StringRef::starts_with(TargetTriple, "genx")) {
+    if (VCINTR::StringRef::starts_with(TargetTriple, "genx32"))
       M.setTargetTriple("spir");
     else
       M.setTargetTriple("spir64");


### PR DESCRIPTION
These four commits are enough to suppress all of the deprecation warnings I see when building with LLVM 17 and tip.

I don't know if I've missed the mark in some of these. For the absence of doubt, I'm assuming you only support or build with stock LLVMs for which these methods always return a certain value, but I'm aware you might want to support other custom versions of LLVM with typed pointer support beyond LLVM 17.