### PR TITLE
Fix build fail -- HalfVecArgument removed from llorg in 62fd4d18e52e61fe1e67cbf9d1c4355a34f84325

### DIFF
--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp
@@ -242,7 +242,7 @@ DecodeIITType(unsigned &NextElt, ArrayRef<unsigned char> Infos,
   case IIT_HALF_VEC_ARG: {
     unsigned ArgInfo = (NextElt == Infos.size() ? 0 : Infos[NextElt++]);
     OutputTable.push_back(IITDescriptor::get(IITDescriptor::OneNthEltsVecArgument,
-                                             ArgInfo));
+                                             2, ArgInfo));
     return;
   }
   case IIT_SAME_VEC_WIDTH_ARG: {

--- a/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp
+++ b/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp
@@ -241,7 +241,7 @@ DecodeIITType(unsigned &NextElt, ArrayRef<unsigned char> Infos,
   }
   case IIT_HALF_VEC_ARG: {
     unsigned ArgInfo = (NextElt == Infos.size() ? 0 : Infos[NextElt++]);
-    OutputTable.push_back(IITDescriptor::get(IITDescriptor::HalfVecArgument,
+    OutputTable.push_back(IITDescriptor::get(IITDescriptor::OneNthEltsVecArgument,
                                              ArgInfo));
     return;
   }
@@ -345,7 +345,7 @@ static Type *DecodeFixedType(ArrayRef<Intrinsic::IITDescriptor> &Infos,
     assert(ITy->getBitWidth() % 2 == 0);
     return IntegerType::get(Context, ITy->getBitWidth() / 2);
   }
-  case IITDescriptor::HalfVecArgument:
+  case IITDescriptor::OneNthEltsVecArgument:
     return VectorType::getHalfElementsVectorType(cast<VectorType>(
                                                   Tys[D.getArgumentNumber()]));
   case IITDescriptor::SameVecWidthArgument: {


### PR DESCRIPTION
The Half/OneThird/etc/VecArgument types were consolidated into OneNthEltsVecArgument. This patch introduces this here as well.